### PR TITLE
Feat 01: Add SmartSan software demo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ The current prototype design combines automatic dispensing, sanitizer level moni
 
 ## Current Repository Status
 
-This repository currently includes an initial **mock dashboard page** for the SmartSan system.
+This repository currently includes a mock dashboard, software planning documents, and an ESP32 firmware skeleton for the SmartSan system.
 
 At this stage:
 - the dashboard is built with HTML, CSS, and JavaScript
-- the displayed values are **mock data**
+- the displayed values are **mock data following the planned ESP32/Blynk data contract**
+- the firmware can run with simulated hardware while the real components are in transit
 - the page is intended to simulate the future monitoring workflow before hardware arrives
 
 ## Current Design Overview
@@ -19,23 +20,48 @@ The current SmartSan design is based on:
 - **IR sensor** for hand detection
 - **servo motor** for bottle pressing
 - **load cell + HX711** for sanitizer level monitoring
-- **Wi-Fi browser interface** for status display
+- **Blynk dashboard** as the primary mobile dashboard
+- **local browser interface** as a mock/demo fallback
 
 The current software flow is planned as:
 
-IR detects hand -> servo presses bottle -> usage count updates -> weight is read and stabilised -> refill status is checked -> status is sent to the web page
+IR detects hand -> servo presses bottle -> usage count updates -> weight is read and stabilised -> refill status is checked -> status is sent to Blynk/dashboard
 
 ## Dashboard Features (Mock Version)
 
 The current dashboard shows:
 - usage count
 - current weight
+- remaining level percentage
 - sanitizer status
 - device state
+- device online state
 - refill threshold
+- last dispense time
 - last updated time
 
-It also includes a **Simulate 1 Dispense** button to preview the expected monitoring workflow.
+It also includes demo controls for simulated sensor dispense, manual dispense, alert reset, and system enable/disable.
+
+## Firmware Skeleton
+
+The ESP32 Arduino sketch is available at:
+
+- `firmware/SmartSanESP32/SmartSanESP32.ino`
+
+By default, the sketch uses mock hardware mode:
+
+- Serial Monitor input `d` simulates a valid hand-detection event
+- Blynk virtual pins are updated using the planned dashboard data contract
+- hardware adapter functions are isolated so they can later be replaced with real IR, servo, and HX711 logic
+
+Before uploading to an ESP32, replace the placeholder Blynk and Wi-Fi values in the sketch.
+
+## Software Documents
+
+- `docs/software_functionalities.md` summarises the software features.
+- `docs/blynk_dashboard.md` defines the Blynk dashboard widgets and virtual pins.
+- `docs/data_contract.md` defines the fields shared between firmware and dashboard.
+- `docs/integration_test_plan.md` lists the hardware integration and evidence checklist.
 
 ## How to Run
 
@@ -55,6 +81,14 @@ Use **Live Server** in VS Code:
 
 ```text
 CITS5506_GROUP_PROJECT/
+├─ docs/
+│  ├─ blynk_dashboard.md
+│  ├─ data_contract.md
+│  ├─ integration_test_plan.md
+│  └─ software_functionalities.md
+├─ firmware/
+│  └─ SmartSanESP32/
+│     └─ SmartSanESP32.ino
 ├─ src/
 │  └─ index.html
 └─ README.md

--- a/docs/blynk_dashboard.md
+++ b/docs/blynk_dashboard.md
@@ -1,0 +1,50 @@
+# SmartSan Blynk Dashboard Setup
+
+This project uses Blynk as the primary dashboard platform because it gives the team a mobile-friendly demo quickly while the hardware and 3D printed enclosure are still being prepared.
+
+## Blynk Template
+
+Create one Blynk template for the prototype:
+
+- Template name: `SmartSan Prototype`
+- Hardware: `ESP32`
+- Connection type: `WiFi`
+- Device name: `SmartSan Demo Unit`
+
+Keep Adafruit IO as a backup for data logging only. The main demo should use Blynk first so the flow is easy to show on a phone.
+
+## Virtual Pin Map
+
+| Virtual Pin | Field | Type | Unit | Direction | Suggested Widget |
+| --- | --- | --- | --- | --- | --- |
+| `V0` | `usageCount` | Integer | events | ESP32 to Blynk | Value Display |
+| `V1` | `currentWeight` | Float | g | ESP32 to Blynk | Gauge or Value Display |
+| `V2` | `remainingPercent` | Integer | % | ESP32 to Blynk | Gauge |
+| `V3` | `refillAlert` | Integer | 0/1 | ESP32 to Blynk | LED or Label |
+| `V4` | `deviceState` | String | none | ESP32 to Blynk | Label |
+| `V5` | `lastDispenseAt` | String | time | ESP32 to Blynk | Label |
+| `V6` | `deviceOnline` | Integer | 0/1 | ESP32 to Blynk | LED |
+| `V10` | `manualDispense` | Integer | 0/1 | Blynk to ESP32 | Button |
+| `V11` | `resetAlert` | Integer | 0/1 | Blynk to ESP32 | Button |
+| `V12` | `systemEnabled` | Integer | 0/1 | Blynk to ESP32 | Switch |
+
+## Dashboard Layout
+
+Use this layout for the first demo:
+
+- Top row: device online, system state, refill alert.
+- Main metrics: usage count, current weight, remaining percentage.
+- Activity: last dispense time.
+- Controls: manual dispense, reset alert, system enable switch.
+
+## Update Rules
+
+- Send status updates every 5 seconds while idle.
+- Send immediate updates after a valid dispense event.
+- Send immediate updates when refill alert changes.
+- Treat `refillAlert = 1` when `currentWeight <= refillThreshold`.
+- Use `systemEnabled = 0` to block manual and sensor-triggered dispensing during testing.
+
+## Demo Notes
+
+The Blynk dashboard should be ready before the hardware arrives. During early testing, the ESP32 sketch can send simulated values to these virtual pins so the team can verify the dashboard workflow without sensors connected.

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -1,0 +1,76 @@
+# SmartSan Data Contract
+
+This document defines the software interface between the ESP32 firmware, the Blynk dashboard, and the local mock dashboard.
+
+## Status Payload
+
+| Field | Type | Unit | Source | Update Frequency | Description |
+| --- | --- | --- | --- | --- | --- |
+| `usageCount` | Integer | events | ESP32 state | After dispense and every 5 seconds | Total valid dispense events since reset |
+| `currentWeight` | Float | g | HX711/load cell | After stabilised reading and every 5 seconds | Latest averaged bottle weight |
+| `remainingPercent` | Integer | % | ESP32 calculation | After weight update | Estimated sanitizer remaining percentage |
+| `refillAlert` | Boolean | none | ESP32 threshold logic | On change and every 5 seconds | `true` when refill is required |
+| `deviceState` | String | none | ESP32 state machine | On state change | Current software state |
+| `deviceOnline` | Boolean | none | ESP32/Blynk connection | Every 5 seconds | Whether the device is connected |
+| `systemEnabled` | Boolean | none | Blynk/local control | On change | Allows or blocks dispensing |
+| `handDetected` | Boolean | none | IR sensor | During detection and state update | Whether a valid hand event is active |
+| `lastDispenseAt` | String | time | ESP32 clock/runtime | After dispense | Last successful dispense timestamp or runtime label |
+| `message` | String | none | ESP32 state machine | On state change | Human-readable dashboard message |
+
+## State Values
+
+Use these values consistently in firmware and dashboard displays:
+
+- `IDLE`
+- `HAND_DETECTED`
+- `DISPENSING`
+- `WAIT_STABILISE`
+- `READ_WEIGHT`
+- `UPDATE_STATUS`
+- `REFILL_REQUIRED`
+- `DISABLED`
+- `ERROR`
+
+## Thresholds and Timing
+
+| Name | Default | Purpose |
+| --- | --- | --- |
+| `refillThreshold` | `250 g` | Trigger refill alert when weight is at or below this value |
+| `fullWeight` | `520 g` | Starting demo weight used to estimate remaining percentage |
+| `emptyWeight` | `120 g` | Approximate bottle/platform weight used for percentage calculation |
+| `dispenseLockoutMs` | `2000 ms` | Prevent repeated dispensing from one hand gesture |
+| `stabiliseDelayMs` | `1200 ms` | Wait after servo movement before reading weight |
+| `statusIntervalMs` | `5000 ms` | Regular idle dashboard update interval |
+| `weightSamples` | `10` | Number of load cell readings to average |
+
+## Alert Logic
+
+The basic refill condition is:
+
+```text
+refillAlert = currentWeight <= refillThreshold
+```
+
+The remaining percentage is:
+
+```text
+remainingPercent = clamp((currentWeight - emptyWeight) / (fullWeight - emptyWeight) * 100, 0, 100)
+```
+
+## Control Inputs
+
+| Control | Source | Expected Value | Behaviour |
+| --- | --- | --- | --- |
+| `manualDispense` | Blynk button or mock dashboard | `1` when pressed | Runs one dispense cycle if `systemEnabled = true` |
+| `resetAlert` | Blynk button or mock dashboard | `1` when pressed | Clears the visible alert after refill/testing |
+| `systemEnabled` | Blynk switch or mock dashboard | `0` or `1` | Disables or enables automatic and manual dispensing |
+
+## Hardware-Abstraction Rule
+
+Before hardware arrives, firmware functions may return simulated values. After hardware arrives, only these hardware adapter functions should need replacement:
+
+- `readHandDetected()`
+- `performDispense()`
+- `readStableWeight()`
+
+The state machine, Blynk virtual pin mapping, and dashboard fields should remain unchanged.

--- a/docs/integration_test_plan.md
+++ b/docs/integration_test_plan.md
@@ -1,0 +1,64 @@
+# SmartSan Hardware Integration Test Plan
+
+Use this checklist when the ordered hardware and 3D printed part are available. Test each subsystem before assembling the full enclosure.
+
+## Phase 1: ESP32 and Blynk
+
+| Test | Method | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| Wi-Fi connection | Upload the firmware with real Wi-Fi and Blynk credentials | Device appears online in Blynk | Screenshot of online widget |
+| Virtual pin update | Run mock mode and send `d` in Serial Monitor | `usageCount`, `currentWeight`, and `deviceState` update | Screenshot of Blynk dashboard |
+| Control inputs | Press manual dispense, reset alert, and system enable switch | ESP32 state changes correctly | Short video or screenshots |
+
+## Phase 2: IR Sensor
+
+| Test | Method | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| Basic detection | Print raw/digital IR reading in Serial Monitor | Hand presence is clearly detectable | Serial output screenshot |
+| False trigger check | Leave the sensor idle for 2 minutes | No unexpected dispense event | Serial output or observation |
+| Lockout check | Hold hand near sensor | Only one dispense event occurs per lockout period | Serial output or video |
+
+## Phase 3: Servo Mechanism
+
+| Test | Method | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| Servo angle sweep | Test press and return angles without sanitizer bottle | Servo moves smoothly and returns | Short video |
+| Bottle press | Mount bottle and trigger one press | One usable sanitizer output is produced | Short video |
+| Power stability | Trigger repeated presses | ESP32 does not reset or disconnect | Observation notes |
+
+## Phase 4: HX711 and Load Cell
+
+| Test | Method | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| Tare | Read empty platform/bottle holder weight | Reading is near zero after tare | Serial output |
+| Calibration | Place known weight or fixed bottle amount | Reading is stable and plausible | Serial output |
+| Stabilised reading | Average multiple readings after a dispense | Weight decreases after dispense without large noise | Serial output |
+| Refill threshold | Reduce weight below threshold | `refillAlert` becomes true | Dashboard screenshot |
+
+## Phase 5: Full System
+
+| Test | Method | Expected Result | Evidence |
+| --- | --- | --- | --- |
+| End-to-end dispense | Hand triggers IR sensor | Servo presses, usage count increments, weight updates, dashboard refreshes | Video of complete flow |
+| Low sanitizer flow | Simulate or create low bottle weight | Dashboard shows refill warning | Screenshot |
+| Reset after refill | Restore weight and press reset alert | Status returns to normal | Screenshot |
+| 3D printed enclosure test | Install all components in printed structure | IR alignment, servo motion, and weight reading remain reliable | Video and notes |
+
+## Recommended Integration Order
+
+1. Keep the firmware in mock mode until Blynk widgets and virtual pins are confirmed.
+2. Replace `readHandDetected()` with real IR logic and test without servo movement.
+3. Replace `performDispense()` with real servo control and test without the load cell.
+4. Replace `readStableWeight()` with HX711 averaging after tare/calibration.
+5. Assemble the 3D printed structure only after the electronics work on the bench.
+6. Recalibrate servo angles and load cell readings after final assembly.
+
+## Demo Acceptance Criteria
+
+The final demo is acceptable when one hand-triggered event can reliably produce this complete chain:
+
+```text
+IR detection -> servo press -> usage count +1 -> weight reading -> refill decision -> Blynk/dashboard update
+```
+
+Collect at least one screenshot or short video for each major subsystem. These become useful evidence for the final report and presentation.

--- a/docs/software_functionalities.md
+++ b/docs/software_functionalities.md
@@ -9,12 +9,14 @@ The current SmartSan prototype is based on:
 - IR sensor for hand detection
 - Servo motor for bottle pressing
 - Load cell with HX711 for sanitizer level monitoring
-- Wi-Fi browser interface for status display
+- Blynk dashboard as the primary mobile interface
+- Local browser interface as a mock/demo fallback
 
 The current direction is to:
 - use the weight sensor as the primary level-monitoring method
 - keep ToF only as a backup option
 - focus first on a reliable monitoring workflow instead of advanced analytics
+- use simulated sensor values before hardware arrives so the software flow can be tested early
 
 ---
 
@@ -147,8 +149,8 @@ The software manages the sequence of system states so the workflow happens in th
 
 ---
 
-### 9. Wi-Fi Status Transmission
-The ESP32 sends the latest system variables to the browser interface.
+### 9. Wi-Fi / Blynk Status Transmission
+The ESP32 sends the latest system variables to Blynk and can also support the local browser mock interface during development.
 
 **Purpose**
 - make monitoring information visible through the web page
@@ -196,6 +198,11 @@ The current software priority is:
 7. refill alert logic
 8. Wi-Fi status transmission
 9. web monitoring display
+
+The implementation details are split across:
+- `blynk_dashboard.md` for Blynk virtual pins and widgets
+- `data_contract.md` for shared ESP32/dashboard fields
+- `integration_test_plan.md` for hardware arrival and final demo testing
 
 ---
 

--- a/firmware/SmartSanESP32/SmartSanESP32.ino
+++ b/firmware/SmartSanESP32/SmartSanESP32.ino
@@ -1,0 +1,260 @@
+/*
+  SmartSan ESP32 firmware skeleton.
+
+  This sketch is designed to run before the final hardware arrives. By default it
+  uses simulated IR, servo, and HX711 behaviour so the Blynk dashboard and state
+  machine can be tested early. Set USE_MOCK_HARDWARE to 0 when the real sensors
+  are ready and replace the hardware adapter functions near the bottom.
+*/
+
+#define BLYNK_TEMPLATE_ID "REPLACE_WITH_TEMPLATE_ID"
+#define BLYNK_TEMPLATE_NAME "SmartSan Prototype"
+#define BLYNK_AUTH_TOKEN "REPLACE_WITH_DEVICE_AUTH_TOKEN"
+
+#include <WiFi.h>
+#include <BlynkSimpleEsp32.h>
+
+#define USE_MOCK_HARDWARE 1
+
+const char WIFI_SSID[] = "REPLACE_WITH_WIFI_NAME";
+const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";
+
+const int PIN_USAGE_COUNT = V0;
+const int PIN_CURRENT_WEIGHT = V1;
+const int PIN_REMAINING_PERCENT = V2;
+const int PIN_REFILL_ALERT = V3;
+const int PIN_DEVICE_STATE = V4;
+const int PIN_LAST_DISPENSE_AT = V5;
+const int PIN_DEVICE_ONLINE = V6;
+const int PIN_MANUAL_DISPENSE = V10;
+const int PIN_RESET_ALERT = V11;
+const int PIN_SYSTEM_ENABLED = V12;
+
+const float FULL_WEIGHT_G = 520.0;
+const float EMPTY_WEIGHT_G = 120.0;
+const float REFILL_THRESHOLD_G = 250.0;
+const unsigned long DISPENSE_LOCKOUT_MS = 2000;
+const unsigned long STABILISE_DELAY_MS = 1200;
+const unsigned long STATUS_INTERVAL_MS = 5000;
+
+enum DeviceState {
+  IDLE,
+  HAND_DETECTED,
+  DISPENSING,
+  WAIT_STABILISE,
+  READ_WEIGHT,
+  UPDATE_STATUS,
+  REFILL_REQUIRED,
+  DISABLED,
+  ERROR_STATE
+};
+
+DeviceState deviceState = IDLE;
+
+int usageCount = 0;
+float currentWeight = FULL_WEIGHT_G;
+bool refillAlert = false;
+bool systemEnabled = true;
+bool manualDispenseRequested = false;
+bool resetAlertRequested = false;
+unsigned long lastDispenseMs = 0;
+unsigned long stateStartedMs = 0;
+unsigned long lastStatusMs = 0;
+
+String stateToString(DeviceState state) {
+  switch (state) {
+    case IDLE:
+      return "IDLE";
+    case HAND_DETECTED:
+      return "HAND_DETECTED";
+    case DISPENSING:
+      return "DISPENSING";
+    case WAIT_STABILISE:
+      return "WAIT_STABILISE";
+    case READ_WEIGHT:
+      return "READ_WEIGHT";
+    case UPDATE_STATUS:
+      return "UPDATE_STATUS";
+    case REFILL_REQUIRED:
+      return "REFILL_REQUIRED";
+    case DISABLED:
+      return "DISABLED";
+    default:
+      return "ERROR";
+  }
+}
+
+int calculateRemainingPercent(float weight) {
+  float usableRange = FULL_WEIGHT_G - EMPTY_WEIGHT_G;
+  float percent = ((weight - EMPTY_WEIGHT_G) / usableRange) * 100.0;
+
+  if (percent < 0) {
+    return 0;
+  }
+
+  if (percent > 100) {
+    return 100;
+  }
+
+  return round(percent);
+}
+
+void setState(DeviceState nextState) {
+  deviceState = nextState;
+  stateStartedMs = millis();
+  sendStatus();
+}
+
+void sendStatus() {
+  Blynk.virtualWrite(PIN_USAGE_COUNT, usageCount);
+  Blynk.virtualWrite(PIN_CURRENT_WEIGHT, currentWeight);
+  Blynk.virtualWrite(PIN_REMAINING_PERCENT, calculateRemainingPercent(currentWeight));
+  Blynk.virtualWrite(PIN_REFILL_ALERT, refillAlert ? 1 : 0);
+  Blynk.virtualWrite(PIN_DEVICE_STATE, stateToString(deviceState));
+  Blynk.virtualWrite(PIN_LAST_DISPENSE_AT, lastDispenseMs == 0 ? "--" : String(lastDispenseMs / 1000) + "s");
+  Blynk.virtualWrite(PIN_DEVICE_ONLINE, Blynk.connected() ? 1 : 0);
+}
+
+bool canStartDispense() {
+  if (!systemEnabled) {
+    setState(DISABLED);
+    return false;
+  }
+
+  if (millis() - lastDispenseMs < DISPENSE_LOCKOUT_MS) {
+    return false;
+  }
+
+  return deviceState == IDLE || deviceState == REFILL_REQUIRED;
+}
+
+void startDispenseCycle() {
+  if (!canStartDispense()) {
+    return;
+  }
+
+  setState(HAND_DETECTED);
+}
+
+void updateStateMachine() {
+  switch (deviceState) {
+    case IDLE:
+    case REFILL_REQUIRED:
+      if (manualDispenseRequested || readHandDetected()) {
+        manualDispenseRequested = false;
+        startDispenseCycle();
+      }
+      break;
+
+    case HAND_DETECTED:
+      performDispense();
+      setState(DISPENSING);
+      break;
+
+    case DISPENSING:
+      usageCount += 1;
+      lastDispenseMs = millis();
+      setState(WAIT_STABILISE);
+      break;
+
+    case WAIT_STABILISE:
+      if (millis() - stateStartedMs >= STABILISE_DELAY_MS) {
+        setState(READ_WEIGHT);
+      }
+      break;
+
+    case READ_WEIGHT:
+      currentWeight = readStableWeight();
+      refillAlert = currentWeight <= REFILL_THRESHOLD_G;
+      setState(UPDATE_STATUS);
+      break;
+
+    case UPDATE_STATUS:
+      setState(refillAlert ? REFILL_REQUIRED : IDLE);
+      break;
+
+    case DISABLED:
+      if (systemEnabled) {
+        setState(refillAlert ? REFILL_REQUIRED : IDLE);
+      }
+      break;
+
+    case ERROR_STATE:
+      break;
+  }
+
+  if (resetAlertRequested) {
+    resetAlertRequested = false;
+    currentWeight = FULL_WEIGHT_G;
+    refillAlert = false;
+    setState(systemEnabled ? IDLE : DISABLED);
+  }
+}
+
+BLYNK_WRITE(V10) {
+  manualDispenseRequested = param.asInt() == 1;
+}
+
+BLYNK_WRITE(V11) {
+  resetAlertRequested = param.asInt() == 1;
+}
+
+BLYNK_WRITE(V12) {
+  systemEnabled = param.asInt() == 1;
+  setState(systemEnabled ? IDLE : DISABLED);
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(100);
+
+  Blynk.begin(BLYNK_AUTH_TOKEN, WIFI_SSID, WIFI_PASS);
+  setState(IDLE);
+}
+
+void loop() {
+  Blynk.run();
+  updateStateMachine();
+
+  if (millis() - lastStatusMs >= STATUS_INTERVAL_MS) {
+    lastStatusMs = millis();
+    sendStatus();
+  }
+}
+
+bool readHandDetected() {
+#if USE_MOCK_HARDWARE
+  if (Serial.available() == 0) {
+    return false;
+  }
+
+  char command = Serial.read();
+  return command == 'd' || command == 'D';
+#else
+  // TODO: Replace with real IR sensor read, including threshold/debounce logic.
+  return false;
+#endif
+}
+
+void performDispense() {
+#if USE_MOCK_HARDWARE
+  Serial.println("Mock dispense: servo press and return");
+#else
+  // TODO: Replace with servo write angles and timing once the mechanism is built.
+#endif
+}
+
+float readStableWeight() {
+#if USE_MOCK_HARDWARE
+  currentWeight -= 18.0;
+
+  if (currentWeight < EMPTY_WEIGHT_G) {
+    currentWeight = EMPTY_WEIGHT_G;
+  }
+
+  return currentWeight;
+#else
+  // TODO: Replace with HX711 averaging after tare/calibration.
+  return currentWeight;
+#endif
+}

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(5, minmax(0, 1fr));
       gap: 16px;
       margin-bottom: 24px;
     }
@@ -150,6 +150,31 @@
       color: #111827;
     }
 
+    button.danger {
+      background: #b91c1c;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .toggle-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px;
+      background: #f9fafb;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+    }
+
+    .toggle-row label {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
     .footer-note {
       margin-top: 20px;
       color: var(--muted);
@@ -185,7 +210,7 @@
         <h1>SmartSan Dashboard</h1>
         <p>
           Mock monitoring interface for the current prototype design.<br>
-          This version uses simulated data so the layout and workflow can be built before hardware arrives.
+          This version follows the planned ESP32/Blynk data contract while the hardware is in transit.
         </p>
       </div>
       <div class="status-pill" id="lastUpdatedPill">Last updated: --</div>
@@ -205,6 +230,12 @@
       </div>
 
       <div class="card">
+        <h2>Remaining Level</h2>
+        <p class="metric" id="remainingPercent">0%</p>
+        <div class="subtext">Estimated from full and empty weight</div>
+      </div>
+
+      <div class="card">
         <h2>Sanitizer Status</h2>
         <p class="metric good" id="sanitizerStatus">NORMAL</p>
         <div class="subtext">Threshold-based refill monitoring</div>
@@ -215,6 +246,12 @@
         <p class="metric" style="font-size: 24px;" id="deviceState">IDLE</p>
         <div class="subtext" id="deviceMessage">System ready</div>
       </div>
+
+      <div class="card">
+        <h2>Device Online</h2>
+        <p class="metric good" id="deviceOnline">ONLINE</p>
+        <div class="subtext">Blynk/Wi-Fi status placeholder</div>
+      </div>
     </section>
 
     <section class="panel-grid">
@@ -223,6 +260,10 @@
         <div class="row">
           <div class="label">Refill Threshold</div>
           <div class="value" id="refillThreshold">250 g</div>
+        </div>
+        <div class="row">
+          <div class="label">Last Dispense Time</div>
+          <div class="value" id="lastDispenseAt">--</div>
         </div>
         <div class="row">
           <div class="label">Hand Detection</div>
@@ -238,15 +279,21 @@
         </div>
         <div class="row">
           <div class="label">Data Source</div>
-          <div class="value">Mock data</div>
+          <div class="value">Mock data following ESP32 contract</div>
         </div>
       </div>
 
       <div class="card">
         <h2>Demo Controls</h2>
         <div class="controls">
-          <button id="simulateDispenseBtn">Simulate 1 Dispense</button>
-          <button class="secondary" id="resetBtn">Reset Dashboard</button>
+          <div class="toggle-row">
+            <label for="systemEnabledToggle">System enabled</label>
+            <input type="checkbox" id="systemEnabledToggle" checked>
+          </div>
+          <button id="simulateDispenseBtn">Simulate Sensor Dispense</button>
+          <button class="secondary" id="manualDispenseBtn">Manual Dispense</button>
+          <button class="secondary" id="resetAlertBtn">Reset Alert</button>
+          <button class="danger" id="resetBtn">Reset Dashboard</button>
         </div>
         <div class="footer-note">
           This control panel is only for development preview. Later, these values can be replaced with live ESP32 variables from IR detection, servo action, and HX711 readings.
@@ -259,11 +306,17 @@
     const state = {
       usageCount: 0,
       currentWeight: 520,
+      fullWeight: 520,
+      emptyWeight: 120,
       refillThreshold: 250,
       sanitizerLow: false,
       deviceState: 'IDLE',
       deviceMessage: 'System ready',
-      handDetected: false
+      deviceOnline: true,
+      systemEnabled: true,
+      handDetected: false,
+      lastDispenseAt: null,
+      dispenseInProgress: false
     };
 
     function updateTimestamp() {
@@ -273,25 +326,54 @@
     }
 
     function render() {
+      const remainingPercent = calculateRemainingPercent();
       document.getElementById('usageCount').textContent = state.usageCount;
       document.getElementById('currentWeight').textContent = `${state.currentWeight} g`;
+      document.getElementById('remainingPercent').textContent = `${remainingPercent}%`;
       document.getElementById('refillThreshold').textContent = `${state.refillThreshold} g`;
       document.getElementById('deviceState').textContent = state.deviceState;
       document.getElementById('deviceMessage').textContent = state.deviceMessage;
       document.getElementById('handDetection').textContent = state.handDetected ? 'Valid hand detected' : 'No hand detected';
+      document.getElementById('lastDispenseAt').textContent = state.lastDispenseAt || '--';
+      document.getElementById('systemEnabledToggle').checked = state.systemEnabled;
+      document.getElementById('simulateDispenseBtn').disabled = !state.systemEnabled || state.dispenseInProgress;
+      document.getElementById('manualDispenseBtn').disabled = !state.systemEnabled || state.dispenseInProgress;
 
       const sanitizerStatusEl = document.getElementById('sanitizerStatus');
       sanitizerStatusEl.textContent = state.sanitizerLow ? 'LOW' : 'NORMAL';
       sanitizerStatusEl.classList.remove('good', 'warn', 'bad');
       sanitizerStatusEl.classList.add(state.sanitizerLow ? 'bad' : 'good');
 
+      const onlineEl = document.getElementById('deviceOnline');
+      onlineEl.textContent = state.deviceOnline ? 'ONLINE' : 'OFFLINE';
+      onlineEl.classList.remove('good', 'warn', 'bad');
+      onlineEl.classList.add(state.deviceOnline ? 'good' : 'bad');
+
       updateTimestamp();
     }
 
-    function simulateDispense() {
+    function calculateRemainingPercent() {
+      const usableRange = state.fullWeight - state.emptyWeight;
+      const rawPercent = ((state.currentWeight - state.emptyWeight) / usableRange) * 100;
+      return Math.max(0, Math.min(100, Math.round(rawPercent)));
+    }
+
+    function setDisabledState() {
+      state.deviceState = 'DISABLED';
+      state.deviceMessage = 'System disabled from dashboard control';
+      state.handDetected = false;
+      render();
+    }
+
+    function simulateDispense(source = 'sensor') {
+      if (!state.systemEnabled || state.dispenseInProgress) {
+        return;
+      }
+
+      state.dispenseInProgress = true;
       state.handDetected = true;
-      state.deviceState = 'HAND DETECTED';
-      state.deviceMessage = 'Valid detection confirmed';
+      state.deviceState = 'HAND_DETECTED';
+      state.deviceMessage = source === 'manual' ? 'Manual dispense requested from dashboard' : 'Valid detection confirmed';
       render();
 
       setTimeout(() => {
@@ -303,6 +385,7 @@
       setTimeout(() => {
         state.usageCount += 1;
         state.currentWeight = Math.max(0, state.currentWeight - 18);
+        state.lastDispenseAt = new Date().toLocaleTimeString();
         state.deviceState = 'WAIT STABILISE';
         state.deviceMessage = 'Applying gated sampling and averaging';
         render();
@@ -310,31 +393,56 @@
 
       setTimeout(() => {
         state.sanitizerLow = state.currentWeight <= state.refillThreshold;
-        state.deviceState = 'UPDATE STATUS';
+        state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'UPDATE_STATUS';
         state.deviceMessage = state.sanitizerLow ? 'Low sanitizer warning generated' : 'System stable and normal';
         render();
       }, 2600);
 
       setTimeout(() => {
         state.handDetected = false;
-        state.deviceState = 'IDLE';
-        state.deviceMessage = 'System ready';
+        state.dispenseInProgress = false;
+        state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'IDLE';
+        state.deviceMessage = state.sanitizerLow ? 'Refill required before normal operation' : 'System ready';
         render();
       }, 3600);
+    }
+
+    function resetAlert() {
+      state.currentWeight = state.fullWeight;
+      state.sanitizerLow = false;
+      state.deviceState = state.systemEnabled ? 'IDLE' : 'DISABLED';
+      state.deviceMessage = 'Alert reset after refill/testing';
+      render();
     }
 
     function resetDashboard() {
       state.usageCount = 0;
       state.currentWeight = 520;
       state.sanitizerLow = false;
+      state.systemEnabled = true;
       state.deviceState = 'IDLE';
       state.deviceMessage = 'System ready';
       state.handDetected = false;
+      state.lastDispenseAt = null;
+      state.dispenseInProgress = false;
       render();
     }
 
-    document.getElementById('simulateDispenseBtn').addEventListener('click', simulateDispense);
+    document.getElementById('simulateDispenseBtn').addEventListener('click', () => simulateDispense('sensor'));
+    document.getElementById('manualDispenseBtn').addEventListener('click', () => simulateDispense('manual'));
+    document.getElementById('resetAlertBtn').addEventListener('click', resetAlert);
     document.getElementById('resetBtn').addEventListener('click', resetDashboard);
+    document.getElementById('systemEnabledToggle').addEventListener('change', (event) => {
+      state.systemEnabled = event.target.checked;
+      if (!state.systemEnabled) {
+        setDisabledState();
+        return;
+      }
+
+      state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'IDLE';
+      state.deviceMessage = state.sanitizerLow ? 'Refill required before normal operation' : 'System ready';
+      render();
+    });
 
     render();
   </script>


### PR DESCRIPTION
## Summary
- Add Blynk dashboard mapping, shared data contract, and hardware integration checklist.
- Expand the mock dashboard into a full software demo workflow for dispense, refill alerts, system enable, and manual controls.
- Add an ESP32 firmware skeleton with mock hardware mode so Blynk/status logic can be tested before components arrive.

## Test plan
- ReadLints reported no diagnostics for the edited files.
- Manual review of the mock dashboard state flow and documented Blynk virtual pins.
- Arduino compile not run because Wi-Fi and Blynk credentials must be supplied before upload.

Closes #1

Made with [Cursor](https://cursor.com)