### PR TITLE
Feat 02: enhance dashboard sync and pump-count contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,29 @@ The current SmartSan design is based on:
 - **ESP32** as the main controller
 - **IR sensor** for hand detection
 - **servo motor** for bottle pressing
-- **load cell + HX711** for sanitizer level monitoring
+- **pump-count based refill estimation** for the current software prototype
 - **Blynk dashboard** as the primary mobile dashboard
 - **local browser interface** as a mock/demo fallback
 
 The current software flow is planned as:
 
-IR detects hand -> servo presses bottle -> usage count updates -> weight is read and stabilised -> refill status is checked -> status is sent to Blynk/dashboard
+IR detects hand -> servo presses bottle -> usage count updates -> remaining pump count is updated -> refill status is checked -> status is sent to Blynk/dashboard
 
 ## Dashboard Features (Mock Version)
 
 The current dashboard shows:
 - usage count
-- current weight
+- remaining pumps
 - remaining level percentage
 - sanitizer status
 - device state
 - device online state
-- refill threshold
+- refill threshold (pump count)
 - last dispense time
+- sync status and last sync time
 - last updated time
 
-It also includes demo controls for simulated sensor dispense, manual dispense, alert reset, and system enable/disable.
+It also includes demo controls for simulated sensor dispense, manual dispense, alert reset, system enable/disable, simulated sync failure, and an event timeline.
 
 ## Firmware Skeleton
 
@@ -62,6 +63,7 @@ Before uploading to an ESP32, replace the placeholder Blynk and Wi-Fi values in 
 - `docs/blynk_dashboard.md` defines the Blynk dashboard widgets and virtual pins.
 - `docs/data_contract.md` defines the fields shared between firmware and dashboard.
 - `docs/integration_test_plan.md` lists the hardware integration and evidence checklist.
+- `docs/software_test_checklist.md` lists software-only validation scenarios before hardware integration.
 
 ## How to Run
 
@@ -85,6 +87,7 @@ CITS5506_GROUP_PROJECT/
 │  ├─ blynk_dashboard.md
 │  ├─ data_contract.md
 │  ├─ integration_test_plan.md
+│  ├─ software_test_checklist.md
 │  └─ software_functionalities.md
 ├─ firmware/
 │  └─ SmartSanESP32/

--- a/docs/blynk_dashboard.md
+++ b/docs/blynk_dashboard.md
@@ -18,12 +18,12 @@ Keep Adafruit IO as a backup for data logging only. The main demo should use Bly
 | Virtual Pin | Field | Type | Unit | Direction | Suggested Widget |
 | --- | --- | --- | --- | --- | --- |
 | `V0` | `usageCount` | Integer | events | ESP32 to Blynk | Value Display |
-| `V1` | `currentWeight` | Float | g | ESP32 to Blynk | Gauge or Value Display |
 | `V2` | `remainingPercent` | Integer | % | ESP32 to Blynk | Gauge |
 | `V3` | `refillAlert` | Integer | 0/1 | ESP32 to Blynk | LED or Label |
 | `V4` | `deviceState` | String | none | ESP32 to Blynk | Label |
 | `V5` | `lastDispenseAt` | String | time | ESP32 to Blynk | Label |
 | `V6` | `deviceOnline` | Integer | 0/1 | ESP32 to Blynk | LED |
+| `V7` | `remainingPumps` | Integer | pumps | ESP32 to Blynk | Value Display |
 | `V10` | `manualDispense` | Integer | 0/1 | Blynk to ESP32 | Button |
 | `V11` | `resetAlert` | Integer | 0/1 | Blynk to ESP32 | Button |
 | `V12` | `systemEnabled` | Integer | 0/1 | Blynk to ESP32 | Switch |
@@ -33,7 +33,7 @@ Keep Adafruit IO as a backup for data logging only. The main demo should use Bly
 Use this layout for the first demo:
 
 - Top row: device online, system state, refill alert.
-- Main metrics: usage count, current weight, remaining percentage.
+- Main metrics: usage count, remaining pumps, remaining percentage.
 - Activity: last dispense time.
 - Controls: manual dispense, reset alert, system enable switch.
 
@@ -42,7 +42,7 @@ Use this layout for the first demo:
 - Send status updates every 5 seconds while idle.
 - Send immediate updates after a valid dispense event.
 - Send immediate updates when refill alert changes.
-- Treat `refillAlert = 1` when `currentWeight <= refillThreshold`.
+- Treat `refillAlert = 1` when `remainingPumps <= 0`.
 - Use `systemEnabled = 0` to block manual and sensor-triggered dispensing during testing.
 
 ## Demo Notes

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -7,8 +7,8 @@ This document defines the software interface between the ESP32 firmware, the Bly
 | Field | Type | Unit | Source | Update Frequency | Description |
 | --- | --- | --- | --- | --- | --- |
 | `usageCount` | Integer | events | ESP32 state | After dispense and every 5 seconds | Total valid dispense events since reset |
-| `currentWeight` | Float | g | HX711/load cell | After stabilised reading and every 5 seconds | Latest averaged bottle weight |
-| `remainingPercent` | Integer | % | ESP32 calculation | After weight update | Estimated sanitizer remaining percentage |
+| `remainingPumps` | Integer | pumps | ESP32 pump counter | After dispense and every 5 seconds | Estimated remaining dispense actions in current refill cycle |
+| `remainingPercent` | Integer | % | ESP32 calculation | After dispense and every 5 seconds | Estimated sanitizer remaining percentage |
 | `refillAlert` | Boolean | none | ESP32 threshold logic | On change and every 5 seconds | `true` when refill is required |
 | `deviceState` | String | none | ESP32 state machine | On state change | Current software state |
 | `deviceOnline` | Boolean | none | ESP32/Blynk connection | Every 5 seconds | Whether the device is connected |
@@ -25,7 +25,7 @@ Use these values consistently in firmware and dashboard displays:
 - `HAND_DETECTED`
 - `DISPENSING`
 - `WAIT_STABILISE`
-- `READ_WEIGHT`
+- `CHECK_REFILL`
 - `UPDATE_STATUS`
 - `REFILL_REQUIRED`
 - `DISABLED`
@@ -35,26 +35,24 @@ Use these values consistently in firmware and dashboard displays:
 
 | Name | Default | Purpose |
 | --- | --- | --- |
-| `refillThreshold` | `250 g` | Trigger refill alert when weight is at or below this value |
-| `fullWeight` | `520 g` | Starting demo weight used to estimate remaining percentage |
-| `emptyWeight` | `120 g` | Approximate bottle/platform weight used for percentage calculation |
+| `maxPumps` | `25` | Number of dispense actions expected from a full refill |
+| `refillThresholdPumps` | `0` | Trigger refill alert when remaining pump count is at or below this value |
 | `dispenseLockoutMs` | `2000 ms` | Prevent repeated dispensing from one hand gesture |
 | `stabiliseDelayMs` | `1200 ms` | Wait after servo movement before reading weight |
 | `statusIntervalMs` | `5000 ms` | Regular idle dashboard update interval |
-| `weightSamples` | `10` | Number of load cell readings to average |
 
 ## Alert Logic
 
 The basic refill condition is:
 
 ```text
-refillAlert = currentWeight <= refillThreshold
+refillAlert = remainingPumps <= refillThresholdPumps
 ```
 
 The remaining percentage is:
 
 ```text
-remainingPercent = clamp((currentWeight - emptyWeight) / (fullWeight - emptyWeight) * 100, 0, 100)
+remainingPercent = clamp((remainingPumps / maxPumps) * 100, 0, 100)
 ```
 
 ## Control Inputs
@@ -67,10 +65,10 @@ remainingPercent = clamp((currentWeight - emptyWeight) / (fullWeight - emptyWeig
 
 ## Hardware-Abstraction Rule
 
-Before hardware arrives, firmware functions may return simulated values. After hardware arrives, only these hardware adapter functions should need replacement:
+Before hardware arrives, firmware functions may return simulated values. After hardware arrives, the hardware adapter functions should remain isolated:
 
 - `readHandDetected()`
 - `performDispense()`
-- `readStableWeight()`
+- `readRemainingPumps()` (or future `readStableWeight()` when HX711 is reintroduced)
 
 The state machine, Blynk virtual pin mapping, and dashboard fields should remain unchanged.

--- a/docs/integration_test_plan.md
+++ b/docs/integration_test_plan.md
@@ -7,7 +7,7 @@ Use this checklist when the ordered hardware and 3D printed part are available. 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
 | Wi-Fi connection | Upload the firmware with real Wi-Fi and Blynk credentials | Device appears online in Blynk | Screenshot of online widget |
-| Virtual pin update | Run mock mode and send `d` in Serial Monitor | `usageCount`, `currentWeight`, and `deviceState` update | Screenshot of Blynk dashboard |
+| Virtual pin update | Run mock mode and send `d` in Serial Monitor | `usageCount`, `remainingPumps`, and `deviceState` update | Screenshot of Blynk dashboard |
 | Control inputs | Press manual dispense, reset alert, and system enable switch | ESP32 state changes correctly | Short video or screenshots |
 
 ## Phase 2: IR Sensor
@@ -26,30 +26,30 @@ Use this checklist when the ordered hardware and 3D printed part are available. 
 | Bottle press | Mount bottle and trigger one press | One usable sanitizer output is produced | Short video |
 | Power stability | Trigger repeated presses | ESP32 does not reset or disconnect | Observation notes |
 
-## Phase 4: HX711 and Load Cell
+## Phase 4: Pump Count and Refill Logic
 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
-| Tare | Read empty platform/bottle holder weight | Reading is near zero after tare | Serial output |
-| Calibration | Place known weight or fixed bottle amount | Reading is stable and plausible | Serial output |
-| Stabilised reading | Average multiple readings after a dispense | Weight decreases after dispense without large noise | Serial output |
-| Refill threshold | Reduce weight below threshold | `refillAlert` becomes true | Dashboard screenshot |
+| Counter update | Trigger repeated dispense cycles in mock mode | `remainingPumps` decreases by one per accepted cycle | Serial output |
+| Lockout safety | Hold trigger input active | Counter increases once per lockout window | Serial output or video |
+| Refill threshold | Continue until `remainingPumps = 0` | `refillAlert` becomes true and state enters `REFILL_REQUIRED` | Dashboard screenshot |
+| Alert reset | Trigger `resetAlert` from Blynk | Counter resets and alert clears | Dashboard screenshot |
 
 ## Phase 5: Full System
 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
-| End-to-end dispense | Hand triggers IR sensor | Servo presses, usage count increments, weight updates, dashboard refreshes | Video of complete flow |
-| Low sanitizer flow | Simulate or create low bottle weight | Dashboard shows refill warning | Screenshot |
-| Reset after refill | Restore weight and press reset alert | Status returns to normal | Screenshot |
-| 3D printed enclosure test | Install all components in printed structure | IR alignment, servo motion, and weight reading remain reliable | Video and notes |
+| End-to-end dispense | Hand triggers IR sensor | Servo presses, usage count increments, remaining count updates, dashboard refreshes | Video of complete flow |
+| Low sanitizer flow | Simulate depleted count (`remainingPumps = 0`) | Dashboard shows refill warning | Screenshot |
+| Reset after refill | Refill and press reset alert | Status returns to normal | Screenshot |
+| 3D printed enclosure test | Install all components in printed structure | IR alignment, servo motion, and counting/sync remain reliable | Video and notes |
 
 ## Recommended Integration Order
 
 1. Keep the firmware in mock mode until Blynk widgets and virtual pins are confirmed.
 2. Replace `readHandDetected()` with real IR logic and test without servo movement.
-3. Replace `performDispense()` with real servo control and test without the load cell.
-4. Replace `readStableWeight()` with HX711 averaging after tare/calibration.
+3. Replace `performDispense()` with real servo control and verify one cycle per trigger.
+4. Validate count and alert logic with repeated trigger tests and reset operations.
 5. Assemble the 3D printed structure only after the electronics work on the bench.
 6. Recalibrate servo angles and load cell readings after final assembly.
 
@@ -58,7 +58,7 @@ Use this checklist when the ordered hardware and 3D printed part are available. 
 The final demo is acceptable when one hand-triggered event can reliably produce this complete chain:
 
 ```text
-IR detection -> servo press -> usage count +1 -> weight reading -> refill decision -> Blynk/dashboard update
+IR detection -> servo press -> usage count +1 -> remaining count update -> refill decision -> Blynk/dashboard update
 ```
 
 Collect at least one screenshot or short video for each major subsystem. These become useful evidence for the final report and presentation.

--- a/docs/software_functionalities.md
+++ b/docs/software_functionalities.md
@@ -8,12 +8,13 @@ The current SmartSan prototype is based on:
 - ESP32 as the main controller
 - IR sensor for hand detection
 - Servo motor for bottle pressing
-- Load cell with HX711 for sanitizer level monitoring
+- pump-count estimation for sanitizer level monitoring (HX711 can be added later)
 - Blynk dashboard as the primary mobile interface
 - Local browser interface as a mock/demo fallback
 
 The current direction is to:
-- use the weight sensor as the primary level-monitoring method
+- use pump-count as the current level-monitoring method
+- keep weight sensor integration as a future enhancement
 - keep ToF only as a backup option
 - focus first on a reliable monitoring workflow instead of advanced analytics
 - use simulated sensor values before hardware arrives so the software flow can be tested early
@@ -69,49 +70,48 @@ Each successful dispense is recorded as one valid usage event.
 
 ---
 
-### 4. Weight Reading
-The system reads bottle weight through the HX711 module and load cell.
+### 4. Remaining Pump Tracking
+The system tracks how many dispense actions are likely left in the current refill cycle.
 
 **Purpose**
-- collect raw weight data for sanitizer level monitoring
+- provide a practical remaining-level estimate before full weight-sensor integration
 
 **Input**
-- HX711 raw readings
+- successful dispense count
+- configured `MAX_PUMPS` per refill
 
 **Output**
-- `rawWeight`
-- `stableWeight`
+- `remainingPumps`
+- `remainingPercent`
 
 ---
 
-### 5. Reading Stabilisation
-The system applies basic stabilisation logic to reduce noise caused by bottle vibration during dispensing.
+### 5. Dispense Lockout and Stabilisation Window
+The system applies lockout and delay logic to avoid repeated dispensing from one gesture.
 
 **Purpose**
-- improve reliability of weight readings
-- avoid false level updates during servo motion
+- prevent accidental rapid re-triggering
+- keep event counting reliable during servo motion
 
 **Logic**
-- gated sampling after dispensing
-- averaging multiple HX711 readings
-- ignoring very small fluctuations as noise
+- lockout period after dispense
+- state transition delay before refill check
 
 **Output**
-- stable processed weight value
+- one counted event per accepted dispense cycle
 
 ---
 
 ### 6. Sanitizer Level Monitoring
-The stable weight value is compared with a refill threshold to determine whether the sanitizer level is normal or low.
+The remaining pump count is compared with a refill threshold to determine whether the sanitizer level is normal or low.
 
 **Purpose**
 - monitor remaining sanitizer level
 - support condition-based refill alerts
 
 **Input**
-- `stableWeight`
-- tare weight
-- refill threshold
+- `remainingPumps`
+- `refillThresholdPumps`
 
 **Output**
 - `sanitizerLow = true/false`
@@ -144,7 +144,7 @@ The software manages the sequence of system states so the workflow happens in th
 - `HAND_DETECTED`
 - `DISPENSING`
 - `WAIT_STABILISE`
-- `READ_WEIGHT`
+- `CHECK_REFILL`
 - `UPDATE_STATUS`
 
 ---
@@ -165,16 +165,18 @@ The ESP32 sends the latest system variables to Blynk and can also support the lo
 
 ---
 
-### 10. Web Monitoring Display
-The browser page shows the most important monitoring information for the current prototype.
+### 10. Web Monitoring Display and Sync Status
+The browser page shows key monitoring information plus sync health for testing without hardware.
 
 **Current Display Fields**
 - usage count
-- current weight
+- remaining pumps
+- remaining percentage
 - sanitizer status
 - device state
 - refill threshold
 - system message
+- sync status and event timeline
 
 ---
 
@@ -182,7 +184,7 @@ The browser page shows the most important monitoring information for the current
 
 The current minimum viable software flow is:
 
-`IR detects hand -> servo presses bottle -> usage count updates -> weight is read and stabilised -> refill status is checked -> status is sent by Wi-Fi -> browser page displays result`
+`IR detects hand -> servo presses bottle -> usage count updates -> remaining count is updated -> refill status is checked -> status is sent by Wi-Fi -> browser page displays result`
 
 ---
 
@@ -192,8 +194,8 @@ The current software priority is:
 1. hand detection
 2. dispensing control
 3. usage event recording
-4. weight reading
-5. reading stabilisation
+4. remaining pump tracking
+5. lockout and stabilisation window
 6. sanitizer level monitoring
 7. refill alert logic
 8. Wi-Fi status transmission
@@ -224,7 +226,7 @@ The software for the current SmartSan design is intended to support:
 - automatic hand detection
 - controlled dispensing
 - usage recording
-- weight-based level monitoring
+- pump-count based level monitoring
 - refill warning
 - browser-based monitoring
 

--- a/docs/software_test_checklist.md
+++ b/docs/software_test_checklist.md
@@ -1,0 +1,36 @@
+# SmartSan Software Test Checklist
+
+This checklist focuses on software functionality that can be validated before full hardware integration.
+
+## Dashboard and State Flow
+
+| Test ID | Scenario | Steps | Expected Result |
+| --- | --- | --- | --- |
+| SW-01 | Sensor-triggered dispense | Click `Simulate Sensor Dispense` | State transitions through `HAND_DETECTED` -> `DISPENSING` -> `WAIT_STABILISE` -> `IDLE/REFILL_REQUIRED` |
+| SW-02 | Manual dispense command | Click `Manual Dispense` | One dispense cycle is executed and `usageCount` increments by 1 |
+| SW-03 | Single-cycle safety | Click dispense repeatedly during one running cycle | Only one active cycle runs, buttons remain disabled until cycle ends |
+| SW-04 | Refill alert trigger | Trigger cycles until `remainingPumps` reaches threshold | `Sanitizer Status` changes to `LOW` and state moves to `REFILL_REQUIRED` |
+| SW-05 | Alert reset path | Click `Reset Alert` | `remainingPumps` resets to max and warning returns to `NORMAL` |
+
+## Sync and Failure Handling
+
+| Test ID | Scenario | Steps | Expected Result |
+| --- | --- | --- | --- |
+| SW-06 | Healthy sync loop | Keep dashboard open for 15+ seconds | `Sync Status` remains `HEALTHY` and `Last Sync` keeps updating |
+| SW-07 | Simulated sync failure | Enable `Simulate sync failure` toggle | `Sync Status` changes to `DEGRADED` and event timeline logs failure |
+| SW-08 | Recovery after failure | Disable `Simulate sync failure` toggle | Sync returns to `HEALTHY`, device returns online, event timeline records recovery |
+
+## Control Safety and Operator Flow
+
+| Test ID | Scenario | Steps | Expected Result |
+| --- | --- | --- | --- |
+| SW-09 | Disable system lock | Turn off `System enabled` | State changes to `DISABLED`, manual/sensor dispense actions are blocked |
+| SW-10 | Re-enable system | Turn on `System enabled` | State returns to `IDLE` or `REFILL_REQUIRED` based on alert status |
+| SW-11 | Dashboard reset | Click `Reset Dashboard` | Counters, status, sync, and timeline reset to defaults |
+
+## Evidence to Capture
+
+- 1 screenshot for normal dispense flow (`SW-01`).
+- 1 screenshot for refill alert (`SW-04`).
+- 1 screenshot for degraded sync and recovery (`SW-07`, `SW-08`).
+- 1 short video showing disabled/enabled safety lock behavior (`SW-09`, `SW-10`).

--- a/firmware/SmartSanESP32/SmartSanESP32.ino
+++ b/firmware/SmartSanESP32/SmartSanESP32.ino
@@ -21,14 +21,13 @@
 // Servo configuration - adjust pin and angles as needed for the actual mechanism
 #define PIN_SERVO         5
 
-#define USE_MOCK_HARDWARE 1 // Set to 0 to use real hardware when ready, needs to be moved abouve the includes
-
-// Hardware libraries (servo only used when not in mock mode)
-#include <ESP32Servo.h>
-#endif
+#define USE_MOCK_HARDWARE 1 // Set to 0 to use real hardware when ready
 
 #include <WiFi.h>
 #include <BlynkSimpleEsp32.h>
+#if !USE_MOCK_HARDWARE
+#include <ESP32Servo.h>
+#endif
 
 //ir sensor variables for debounce logic and stable state detection
 static bool _irLastState = false;

--- a/src/index.html
+++ b/src/index.html
@@ -224,9 +224,9 @@
       </div>
 
       <div class="card">
-        <h2>Current Weight</h2>
-        <p class="metric" id="currentWeight">0 g</p>
-        <div class="subtext">Stable averaged reading</div>
+        <h2>Remaining Pumps</h2>
+        <p class="metric" id="remainingPumps">25</p>
+        <div class="subtext">Pump-count based level estimate</div>
       </div>
 
       <div class="card">
@@ -252,6 +252,12 @@
         <p class="metric good" id="deviceOnline">ONLINE</p>
         <div class="subtext">Blynk/Wi-Fi status placeholder</div>
       </div>
+
+      <div class="card">
+        <h2>Sync Status</h2>
+        <p class="metric" style="font-size: 24px;" id="syncStatus">HEALTHY</p>
+        <div class="subtext" id="syncMessage">Live update loop is stable</div>
+      </div>
     </section>
 
     <section class="panel-grid">
@@ -259,7 +265,7 @@
         <h2>Current System Details</h2>
         <div class="row">
           <div class="label">Refill Threshold</div>
-          <div class="value" id="refillThreshold">250 g</div>
+          <div class="value" id="refillThreshold">0 pumps</div>
         </div>
         <div class="row">
           <div class="label">Last Dispense Time</div>
@@ -275,11 +281,15 @@
         </div>
         <div class="row">
           <div class="label">Reading Mode</div>
-          <div class="value">Gated sampling + averaging</div>
+          <div class="value">Pump count + state machine</div>
         </div>
         <div class="row">
           <div class="label">Data Source</div>
-          <div class="value">Mock data following ESP32 contract</div>
+          <div class="value" id="dataSource">Mock data following ESP32 contract</div>
+        </div>
+        <div class="row">
+          <div class="label">Last Sync</div>
+          <div class="value" id="lastSyncAt">--</div>
         </div>
       </div>
 
@@ -290,33 +300,46 @@
             <label for="systemEnabledToggle">System enabled</label>
             <input type="checkbox" id="systemEnabledToggle" checked>
           </div>
+          <div class="toggle-row">
+            <label for="syncFailureToggle">Simulate sync failure</label>
+            <input type="checkbox" id="syncFailureToggle">
+          </div>
           <button id="simulateDispenseBtn">Simulate Sensor Dispense</button>
           <button class="secondary" id="manualDispenseBtn">Manual Dispense</button>
           <button class="secondary" id="resetAlertBtn">Reset Alert</button>
           <button class="danger" id="resetBtn">Reset Dashboard</button>
         </div>
         <div class="footer-note">
-          This control panel is only for development preview. Later, these values can be replaced with live ESP32 variables from IR detection, servo action, and HX711 readings.
+          This control panel is for software integration preview. The same fields map to Blynk virtual pins used by the ESP32 firmware.
         </div>
       </div>
+    </section>
+
+    <section class="card" style="margin-top: 16px;">
+      <h2>Event Timeline</h2>
+      <div id="eventTimeline" class="subtext">No events yet.</div>
     </section>
   </div>
 
   <script>
     const state = {
       usageCount: 0,
-      currentWeight: 520,
-      fullWeight: 520,
-      emptyWeight: 120,
-      refillThreshold: 250,
+      remainingPumps: 25,
+      maxPumps: 25,
+      refillThresholdPumps: 0,
       sanitizerLow: false,
       deviceState: 'IDLE',
       deviceMessage: 'System ready',
       deviceOnline: true,
+      syncHealthy: true,
+      syncFailureSimulated: false,
       systemEnabled: true,
       handDetected: false,
       lastDispenseAt: null,
-      dispenseInProgress: false
+      dispenseInProgress: false,
+      lastSyncAt: null,
+      eventTimeline: [],
+      dataSource: 'Mock data following ESP32 contract'
     };
 
     function updateTimestamp() {
@@ -328,14 +351,17 @@
     function render() {
       const remainingPercent = calculateRemainingPercent();
       document.getElementById('usageCount').textContent = state.usageCount;
-      document.getElementById('currentWeight').textContent = `${state.currentWeight} g`;
+      document.getElementById('remainingPumps').textContent = `${state.remainingPumps}`;
       document.getElementById('remainingPercent').textContent = `${remainingPercent}%`;
-      document.getElementById('refillThreshold').textContent = `${state.refillThreshold} g`;
+      document.getElementById('refillThreshold').textContent = `${state.refillThresholdPumps} pumps`;
       document.getElementById('deviceState').textContent = state.deviceState;
       document.getElementById('deviceMessage').textContent = state.deviceMessage;
       document.getElementById('handDetection').textContent = state.handDetected ? 'Valid hand detected' : 'No hand detected';
       document.getElementById('lastDispenseAt').textContent = state.lastDispenseAt || '--';
+      document.getElementById('lastSyncAt').textContent = state.lastSyncAt || '--';
+      document.getElementById('dataSource').textContent = state.dataSource;
       document.getElementById('systemEnabledToggle').checked = state.systemEnabled;
+      document.getElementById('syncFailureToggle').checked = state.syncFailureSimulated;
       document.getElementById('simulateDispenseBtn').disabled = !state.systemEnabled || state.dispenseInProgress;
       document.getElementById('manualDispenseBtn').disabled = !state.systemEnabled || state.dispenseInProgress;
 
@@ -349,19 +375,50 @@
       onlineEl.classList.remove('good', 'warn', 'bad');
       onlineEl.classList.add(state.deviceOnline ? 'good' : 'bad');
 
+      const syncEl = document.getElementById('syncStatus');
+      const syncMessageEl = document.getElementById('syncMessage');
+      syncEl.textContent = state.syncHealthy ? 'HEALTHY' : 'DEGRADED';
+      syncMessageEl.textContent = state.syncHealthy
+        ? 'Live update loop is stable'
+        : 'Sync delay detected, waiting for next successful update';
+      syncEl.classList.remove('good', 'warn', 'bad');
+      syncEl.classList.add(state.syncHealthy ? 'good' : 'warn');
+
+      const timelineEl = document.getElementById('eventTimeline');
+      if (state.eventTimeline.length === 0) {
+        timelineEl.textContent = 'No events yet.';
+      } else {
+        timelineEl.innerHTML = state.eventTimeline
+          .slice(0, 8)
+          .map((entry) => `${entry.time} - ${entry.message}`)
+          .join('<br>');
+      }
+
       updateTimestamp();
     }
 
     function calculateRemainingPercent() {
-      const usableRange = state.fullWeight - state.emptyWeight;
-      const rawPercent = ((state.currentWeight - state.emptyWeight) / usableRange) * 100;
-      return Math.max(0, Math.min(100, Math.round(rawPercent)));
+      return Math.max(0, Math.min(100, Math.round((state.remainingPumps / state.maxPumps) * 100)));
+    }
+
+    function recordEvent(message) {
+      state.eventTimeline.unshift({
+        time: new Date().toLocaleTimeString(),
+        message
+      });
+    }
+
+    function updateSyncStatus(success) {
+      state.syncHealthy = success;
+      state.deviceOnline = success;
+      state.lastSyncAt = success ? new Date().toLocaleTimeString() : state.lastSyncAt;
     }
 
     function setDisabledState() {
       state.deviceState = 'DISABLED';
       state.deviceMessage = 'System disabled from dashboard control';
       state.handDetected = false;
+      recordEvent('System disabled by operator');
       render();
     }
 
@@ -374,27 +431,32 @@
       state.handDetected = true;
       state.deviceState = 'HAND_DETECTED';
       state.deviceMessage = source === 'manual' ? 'Manual dispense requested from dashboard' : 'Valid detection confirmed';
+      recordEvent(source === 'manual' ? 'Manual dispense requested' : 'Sensor dispense requested');
       render();
 
       setTimeout(() => {
         state.deviceState = 'DISPENSING';
         state.deviceMessage = 'Servo press triggered';
+        recordEvent('Dispensing cycle started');
         render();
       }, 500);
 
       setTimeout(() => {
         state.usageCount += 1;
-        state.currentWeight = Math.max(0, state.currentWeight - 18);
+        state.remainingPumps = Math.max(0, state.remainingPumps - 1);
         state.lastDispenseAt = new Date().toLocaleTimeString();
         state.deviceState = 'WAIT STABILISE';
-        state.deviceMessage = 'Applying gated sampling and averaging';
+        state.deviceMessage = 'Applying lockout and pump-count update';
         render();
       }, 1200);
 
       setTimeout(() => {
-        state.sanitizerLow = state.currentWeight <= state.refillThreshold;
+        state.sanitizerLow = state.remainingPumps <= state.refillThresholdPumps;
         state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'UPDATE_STATUS';
         state.deviceMessage = state.sanitizerLow ? 'Low sanitizer warning generated' : 'System stable and normal';
+        if (state.sanitizerLow) {
+          recordEvent('Refill alert triggered');
+        }
         render();
       }, 2600);
 
@@ -403,28 +465,44 @@
         state.dispenseInProgress = false;
         state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'IDLE';
         state.deviceMessage = state.sanitizerLow ? 'Refill required before normal operation' : 'System ready';
+        recordEvent('Dispense cycle completed');
         render();
       }, 3600);
     }
 
     function resetAlert() {
-      state.currentWeight = state.fullWeight;
+      state.remainingPumps = state.maxPumps;
       state.sanitizerLow = false;
       state.deviceState = state.systemEnabled ? 'IDLE' : 'DISABLED';
       state.deviceMessage = 'Alert reset after refill/testing';
+      recordEvent('Refill alert reset');
       render();
     }
 
     function resetDashboard() {
       state.usageCount = 0;
-      state.currentWeight = 520;
+      state.remainingPumps = state.maxPumps;
       state.sanitizerLow = false;
       state.systemEnabled = true;
+      state.syncHealthy = true;
+      state.syncFailureSimulated = false;
+      state.deviceOnline = true;
       state.deviceState = 'IDLE';
       state.deviceMessage = 'System ready';
       state.handDetected = false;
       state.lastDispenseAt = null;
+      state.lastSyncAt = null;
       state.dispenseInProgress = false;
+      state.eventTimeline = [];
+      render();
+    }
+
+    function syncTick() {
+      const success = !state.syncFailureSimulated;
+      updateSyncStatus(success);
+      if (!success) {
+        recordEvent('Sync failure simulated');
+      }
       render();
     }
 
@@ -432,6 +510,11 @@
     document.getElementById('manualDispenseBtn').addEventListener('click', () => simulateDispense('manual'));
     document.getElementById('resetAlertBtn').addEventListener('click', resetAlert);
     document.getElementById('resetBtn').addEventListener('click', resetDashboard);
+    document.getElementById('syncFailureToggle').addEventListener('change', (event) => {
+      state.syncFailureSimulated = event.target.checked;
+      recordEvent(state.syncFailureSimulated ? 'Sync failure mode enabled' : 'Sync failure mode disabled');
+      syncTick();
+    });
     document.getElementById('systemEnabledToggle').addEventListener('change', (event) => {
       state.systemEnabled = event.target.checked;
       if (!state.systemEnabled) {
@@ -441,9 +524,11 @@
 
       state.deviceState = state.sanitizerLow ? 'REFILL_REQUIRED' : 'IDLE';
       state.deviceMessage = state.sanitizerLow ? 'Refill required before normal operation' : 'System ready';
+      recordEvent('System enabled');
       render();
     });
 
+    setInterval(syncTick, 5000);
     render();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Align front-end mock dashboard and dashboard docs with the pump-count based firmware prototype.
- Add sync health indicator (HEALTHY/DEGRADED), last sync time, and an event timeline for better demo/test evidence.
- Add UI controls to simulate sync failures and verify recovery paths.
- Update software functionality docs and the integration test plan to match the new pump-count workflow.

## Test plan (no hardware)
- Open `src/index.html` in browser and run:
  - `Simulate Sensor Dispense` multiple times
  - verify state progression + remaining pumps / refill alert
  - toggle `Simulate sync failure` and confirm Sync Status changes
- No Arduino/Blynk compile run because Wi-Fi/Blynk credentials are placeholders.

Made with [Cursor](https://cursor.com)