### PR TITLE
Docs 01: add SmartSan team testing handoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+firmware/SmartSanESP32/secrets.h

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ By default, the sketch uses mock hardware mode:
 - Blynk virtual pins are updated using the planned dashboard data contract
 - hardware adapter functions are isolated so they can later be replaced with real IR, servo, and HX711 logic
 
-Before uploading to an ESP32, replace the placeholder Blynk and Wi-Fi values in the sketch.
+Before uploading to an ESP32, copy `firmware/SmartSanESP32/secrets.example.h` to `firmware/SmartSanESP32/secrets.h` and fill in local Blynk and Wi-Fi values. The local `secrets.h` file is ignored by git.
+
+For team testing instructions, follow `docs/team_testing_guide.md`.
 
 ## Software Documents
 
@@ -64,6 +66,7 @@ Before uploading to an ESP32, replace the placeholder Blynk and Wi-Fi values in 
 - `docs/data_contract.md` defines the fields shared between firmware and dashboard.
 - `docs/integration_test_plan.md` lists the hardware integration and evidence checklist.
 - `docs/software_test_checklist.md` lists software-only validation scenarios before hardware integration.
+- `docs/team_testing_guide.md` gives the step-by-step Blynk, mock firmware, and hardware test handoff.
 
 ## How to Run
 

--- a/docs/team_testing_guide.md
+++ b/docs/team_testing_guide.md
@@ -1,0 +1,123 @@
+# SmartSan Team Testing Guide
+
+Use this guide to test the current SmartSan ESP32 and Blynk integration before the final hardware assembly.
+
+## Current Test Scope
+
+The main firmware is:
+
+```text
+firmware/SmartSanESP32/SmartSanESP32.ino
+```
+
+Do not use `sketch_may7a` for Blynk testing. That sketch only toggles GPIO 2 and does not contain the SmartSan state machine.
+
+The current firmware starts in mock hardware mode:
+
+```cpp
+#define USE_MOCK_HARDWARE 1
+```
+
+In this mode, the real IR sensor and servo are not used. A Serial Monitor command simulates a hand-detection event.
+
+## One-Time Local Setup
+
+1. Open `firmware/SmartSanESP32/SmartSanESP32.ino` in Arduino IDE.
+2. Copy `firmware/SmartSanESP32/secrets.example.h` to `firmware/SmartSanESP32/secrets.h`.
+3. Fill `secrets.h` with the Blynk template ID, Blynk auth token, Wi-Fi SSID, and Wi-Fi password.
+4. Keep `secrets.h` local. It is ignored by git and should not be pushed.
+5. In Arduino IDE, select the ESP32 board and the correct serial port.
+6. Set Serial Monitor baud rate to `115200`.
+
+## Blynk Datastream Contract
+
+| Pin | Name | Direction | Expected Use |
+| --- | --- | --- | --- |
+| `V0` | `usageCount` | ESP32 to Blynk | Total accepted dispense count |
+| `V2` | `remainingPercent` | ESP32 to Blynk | Estimated remaining percentage |
+| `V3` | `refillAlert` | ESP32 to Blynk | `1` when refill is required |
+| `V4` | `deviceState` | ESP32 to Blynk | State string such as `IDLE` or `DISPENSING` |
+| `V5` | `lastDispenseAt` | ESP32 to Blynk | Runtime label for last dispense |
+| `V6` | `deviceOnline` | ESP32 to Blynk | `1` when Blynk is connected |
+| `V7` | `remainingPumps` | ESP32 to Blynk | Remaining mock pump count |
+| `V10` | `manualDispense` | Blynk to ESP32 | Button input, send `1` to trigger one cycle |
+| `V11` | `resetAlert` | Blynk to ESP32 | Button input, send `1` to reset refill count |
+| `V12` | `systemEnabled` | Blynk to ESP32 | Switch input, `1` enabled and `0` disabled |
+
+## Mock Firmware Test
+
+1. Upload the firmware with `USE_MOCK_HARDWARE` set to `1`.
+2. Open Serial Monitor at `115200`.
+3. Send `d` or `D`.
+4. Expected Serial Monitor output includes:
+
+```text
+[MOCK] Trigger dispense
+[MOCK] Dispense start
+[MOCK] Dispense end
+[COUNT] Total: 1 | Session: 1 | Remaining: 24
+```
+
+5. Expected Blynk changes:
+   - `usageCount` increases by 1.
+   - `remainingPumps` decreases by 1.
+   - `remainingPercent` updates.
+   - `deviceState` moves through `HAND_DETECTED`, `DISPENSING`, `WAIT_STABILISE`, then back to `IDLE`.
+
+## Blynk Control Test
+
+Run these tests after the mock firmware test works.
+
+| Test | Action | Expected Result |
+| --- | --- | --- |
+| Manual dispense | Press the `manualDispense` widget mapped to `V10` | One dispense cycle runs |
+| Disable system | Set `systemEnabled` on `V12` to `0` | Device state becomes `DISABLED`; dispense is blocked |
+| Re-enable system | Set `systemEnabled` on `V12` to `1` | Device returns to `IDLE` or `REFILL_REQUIRED` |
+| Reset refill alert | Press `resetAlert` on `V11` | `remainingPumps` resets to `25`; alert clears |
+
+## If `d` or `D` Has No Response
+
+Check these items in order:
+
+1. Confirm the uploaded sketch is `firmware/SmartSanESP32/SmartSanESP32.ino`.
+2. Confirm Serial Monitor is set to `115200`.
+3. Confirm `USE_MOCK_HARDWARE` is `1`.
+4. Confirm the ESP32 is connected to Wi-Fi and Blynk. `Blynk.begin(...)` can block the sketch if credentials or token are incorrect.
+5. Confirm `systemEnabled` is `1` in Blynk.
+6. Wait at least 2 seconds between repeated sends because the firmware has a dispense lockout.
+
+## Real Hardware Test
+
+Only move to this phase after the mock and Blynk control tests pass.
+
+1. Install the `ESP32Servo` library in Arduino IDE.
+2. Change the firmware to:
+
+```cpp
+#define USE_MOCK_HARDWARE 0
+```
+
+3. Wire the hardware according to the current firmware constants:
+
+| Hardware | ESP32 GPIO | Firmware Constant |
+| --- | --- | --- |
+| IR sensor digital output | GPIO 2 | `PIN_IR_SENSOR` |
+| Servo signal | GPIO 5 | `PIN_SERVO` |
+
+4. Upload the firmware.
+5. Place a hand near the IR sensor.
+6. Expected result:
+   - Serial Monitor prints `[IR] Hand detected`.
+   - Servo performs one press-and-return cycle.
+   - Blynk metrics update after the accepted cycle.
+
+## Evidence To Capture
+
+Each tester should capture:
+
+- One screenshot of Blynk after a successful mock `d` test.
+- One screenshot or short video of the `manualDispense` Blynk control working.
+- One screenshot showing `systemEnabled = 0` blocks dispensing.
+- If hardware is connected, one short video of IR detection triggering the servo and Blynk updates.
+
+Record any failure with the exact step number, Serial Monitor output, Blynk widget values, and whether mock mode or real hardware mode was used.

--- a/firmware/SmartSanESP32/SmartSanESP32.ino
+++ b/firmware/SmartSanESP32/SmartSanESP32.ino
@@ -8,10 +8,20 @@
   are ready and replace the hardware adapter functions near the bottom.
 */
 
-// Blynk configuration - replace with actual template ID, name, and auth token from your Blynk project
-#define BLYNK_TEMPLATE_ID "REPLACE_WITH_TEMPLATE_ID"
+// Blynk configuration
 #define BLYNK_TEMPLATE_NAME "SmartSan Prototype"
+
+// Copy secrets.example.h to secrets.h and fill in local credentials before upload.
+// secrets.h is intentionally ignored by git so Blynk tokens and Wi-Fi passwords
+// are not pushed to the remote repository.
+#if __has_include("secrets.h")
+#include "secrets.h"
+#else
+#define BLYNK_TEMPLATE_ID "REPLACE_WITH_TEMPLATE_ID"
 #define BLYNK_AUTH_TOKEN "REPLACE_WITH_DEVICE_AUTH_TOKEN"
+const char WIFI_SSID[] = "REPLACE_WITH_WIFI_NAME";
+const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";
+#endif
 
 // IR sensor configuration - adjust as needed for the actual sensor and placement
 #define PIN_IR_SENSOR     2
@@ -44,10 +54,6 @@ const int SERVO_PRESS_DEG = 60;
 const int SERVO_PRESS_MS  = 400;
 const int SERVO_RETURN_MS = 300;
 const int SERVO_SETTLE_MS = 100;
-
-// WiFi credentials - replace with actual network details
-const char WIFI_SSID[] = "REPLACE_WITH_WIFI_NAME";
-const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";
 
 // Blynk virtual pin definitions
 const int PIN_USAGE_COUNT = V0;
@@ -410,4 +416,4 @@ void performDispense() {
 
   Serial.println("[SERVO] Cycle complete");
 #endif
-} 
+}

--- a/firmware/SmartSanESP32/secrets.example.h
+++ b/firmware/SmartSanESP32/secrets.example.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Copy this file to secrets.h and replace the placeholder values before upload.
+// Do not commit secrets.h.
+
+#define BLYNK_TEMPLATE_ID "REPLACE_WITH_TEMPLATE_ID"
+#define BLYNK_AUTH_TOKEN "REPLACE_WITH_DEVICE_AUTH_TOKEN"
+
+const char WIFI_SSID[] = "REPLACE_WITH_WIFI_NAME";
+const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";


### PR DESCRIPTION
## Summary
- Integrate the hardware group sketch into the main SmartSan Blynk firmware.
- Add real hardware mode for VL53L1X distance detection, HX711 liquid-weight measurement, and servo dispensing while keeping mock `d/D` testing available.
- Change dashboard data from pump-count-first to weight-first: `V7 liquidWeightGrams`, optional diagnostics on `V8 distanceMm` and `V9 lastDispenseGrams`.
- Update README and docs so team testing, data contract, Blynk setup, and integration plans match the new hardware workflow.

## Firmware behavior
- Default remains `USE_MOCK_HARDWARE = 1` for safe Serial/Blynk testing.
- Set `USE_MOCK_HARDWARE = 0` after installing `VL53L1X`, `HX711`, and `ESP32Servo` libraries and selecting the XIAO ESP32 board package with `D1`-style pins.
- Real hardware mapping: servo `D1`, HX711 DT `D2`, HX711 SCK `D3`, VL53L1X SDA `D4`, VL53L1X SCL `D5`.
- The firmware prints CSV samples to Serial Monitor: `time_ms,distance_mm,load_raw,liquid_g,remaining_percent,last_dispense_g,state,event`.
- Blynk connection is now non-blocking, so local Serial testing can continue even when Wi-Fi/Blynk is unavailable.

## Blynk changes required
1. Edit `V7` from `remainingPumps` to `liquidWeightGrams`.
2. Set `V7` data type to `Double`, units `g`, min `0`, max `700`, decimals `1`.
3. Add `V8 distanceMm` as `Integer`, units `mm`, min `0`, max `2000`.
4. Add `V9 lastDispenseGrams` as `Double`, units `g`, min `0`, max `100`, decimals `1`.
5. Keep `V2 remainingPercent` as `0-100%` and `V3 refillAlert` as `0/1`.
6. Click **Save And Apply** in Blynk Console before testing the uploaded firmware.

## Testing instructions
- Mock path: upload with `USE_MOCK_HARDWARE = 1`, open Serial Monitor at `115200`, send `d` or `D`, and confirm `usageCount`, `liquidWeightGrams`, `remainingPercent`, and `deviceState` update.
- Hardware path: switch to `USE_MOCK_HARDWARE = 0`, upload, confirm Serial prints distance/weight CSV samples, place a hand between `70 mm` and `150 mm`, and confirm servo + Blynk updates.
- Collect at least 10 dispense attempts from Serial CSV for data analysis.

## Validation
- Ran `git diff --check`.
- `arduino-cli` is not installed in this local environment, so Arduino compile/upload must be verified from Arduino IDE.

Detailed instructions are in `docs/team_testing_guide.md` and `docs/blynk_dashboard.md`.