### PR TITLE
Feat 04: Align dashboard with hardware datastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ At this stage:
 
 The current SmartSan design is based on:
 - **ESP32** as the main controller
-- **IR sensor** for hand detection
+- **VL53L1X distance sensor** for hand detection
 - **servo motor** for bottle pressing
-- **pump-count based refill estimation** for the current software prototype
+- **HX711 load cell** for weight-based refill estimation
 - **Blynk dashboard** as the primary mobile dashboard
 - **local browser interface** as a mock/demo fallback
 
 The current software flow is planned as:
 
-IR detects hand -> servo presses bottle -> usage count updates -> remaining pump count is updated -> refill status is checked -> status is sent to Blynk/dashboard
+Distance sensor detects hand -> servo presses bottle -> usage count updates -> liquid weight and remaining percentage are updated -> refill status is checked -> status is sent to Blynk/dashboard
 
 ## Dashboard Features (Mock Version)
 
 The current dashboard shows:
 - usage count
-- remaining pumps
+- liquid weight
 - remaining level percentage
 - sanitizer status
 - device state
 - device online state
-- refill threshold (pump count)
+- refill threshold
 - last dispense time
 - sync status and last sync time
 - last updated time

--- a/docs/blynk_dashboard.md
+++ b/docs/blynk_dashboard.md
@@ -23,17 +23,48 @@ Keep Adafruit IO as a backup for data logging only. The main demo should use Bly
 | `V4` | `deviceState` | String | none | ESP32 to Blynk | Label |
 | `V5` | `lastDispenseAt` | String | time | ESP32 to Blynk | Label |
 | `V6` | `deviceOnline` | Integer | 0/1 | ESP32 to Blynk | LED |
-| `V7` | `remainingPumps` | Integer | pumps | ESP32 to Blynk | Value Display |
+| `V7` | `liquidWeightGrams` | Double | g | ESP32 to Blynk | Value Display or Chart |
+| `V8` | `distanceMm` | Integer | mm | ESP32 to Blynk | Value Display |
+| `V9` | `lastDispenseGrams` | Double | g | ESP32 to Blynk | Value Display |
 | `V10` | `manualDispense` | Integer | 0/1 | Blynk to ESP32 | Button |
 | `V11` | `resetAlert` | Integer | 0/1 | Blynk to ESP32 | Button |
 | `V12` | `systemEnabled` | Integer | 0/1 | Blynk to ESP32 | Switch |
+
+## Blynk Console Changes for Weight-Based Firmware
+
+Update the existing template datastreams before uploading the hardware-enabled firmware:
+
+1. Edit `V7`:
+   - Name: `liquidWeightGrams`
+   - Data type: `Double`
+   - Units: `g`
+   - Min: `0`
+   - Max: `700`
+   - Decimals: `1`
+2. Add `V8`:
+   - Name: `distanceMm`
+   - Data type: `Integer`
+   - Units: `mm`
+   - Min: `0`
+   - Max: `2000`
+3. Add `V9`:
+   - Name: `lastDispenseGrams`
+   - Data type: `Double`
+   - Units: `g`
+   - Min: `0`
+   - Max: `100`
+   - Decimals: `1`
+4. Keep `V2` as `remainingPercent` with Min `0`, Max `100`, and units `%`.
+5. Keep `V3` as `refillAlert` with Min `0`, Max `1`.
+6. Click **Save And Apply** after editing the datastreams.
 
 ## Dashboard Layout
 
 Use this layout for the first demo:
 
 - Top row: device online, system state, refill alert.
-- Main metrics: usage count, remaining pumps, remaining percentage.
+- Main metrics: usage count, liquid weight, remaining percentage.
+- Diagnostics: distance reading and last dispense grams.
 - Activity: last dispense time.
 - Controls: manual dispense, reset alert, system enable switch.
 
@@ -42,7 +73,7 @@ Use this layout for the first demo:
 - Send status updates every 5 seconds while idle.
 - Send immediate updates after a valid dispense event.
 - Send immediate updates when refill alert changes.
-- Treat `refillAlert = 1` when `remainingPumps <= 0`.
+- Treat `refillAlert = 1` when `remainingPercent <= 10`.
 - Use `systemEnabled = 0` to block manual and sensor-triggered dispensing during testing.
 
 ## Demo Notes

--- a/docs/data_contract.md
+++ b/docs/data_contract.md
@@ -7,13 +7,15 @@ This document defines the software interface between the ESP32 firmware, the Bly
 | Field | Type | Unit | Source | Update Frequency | Description |
 | --- | --- | --- | --- | --- | --- |
 | `usageCount` | Integer | events | ESP32 state | After dispense and every 5 seconds | Total valid dispense events since reset |
-| `remainingPumps` | Integer | pumps | ESP32 pump counter | After dispense and every 5 seconds | Estimated remaining dispense actions in current refill cycle |
-| `remainingPercent` | Integer | % | ESP32 calculation | After dispense and every 5 seconds | Estimated sanitizer remaining percentage |
+| `liquidWeightGrams` | Float | g | HX711 load cell | Every 5 seconds and after dispense | Estimated remaining liquid weight after empty-bottle tare |
+| `remainingPercent` | Integer | % | ESP32 calculation | After measurement and after dispense | Estimated sanitizer remaining percentage from liquid weight |
+| `distanceMm` | Integer | mm | VL53L1X distance sensor | Every 5 seconds and during detection | Corrected hand-distance reading |
+| `lastDispenseGrams` | Float | g | ESP32 calculation | After dispense stabilisation | Estimated liquid used by the latest accepted dispense |
 | `refillAlert` | Boolean | none | ESP32 threshold logic | On change and every 5 seconds | `true` when refill is required |
 | `deviceState` | String | none | ESP32 state machine | On state change | Current software state |
 | `deviceOnline` | Boolean | none | ESP32/Blynk connection | Every 5 seconds | Whether the device is connected |
 | `systemEnabled` | Boolean | none | Blynk/local control | On change | Allows or blocks dispensing |
-| `handDetected` | Boolean | none | IR sensor | During detection and state update | Whether a valid hand event is active |
+| `handDetected` | Boolean | none | VL53L1X distance range | During detection and state update | Whether a valid hand event is active |
 | `lastDispenseAt` | String | time | ESP32 clock/runtime | After dispense | Last successful dispense timestamp or runtime label |
 | `message` | String | none | ESP32 state machine | On state change | Human-readable dashboard message |
 
@@ -35,24 +37,32 @@ Use these values consistently in firmware and dashboard displays:
 
 | Name | Default | Purpose |
 | --- | --- | --- |
-| `maxPumps` | `25` | Number of dispense actions expected from a full refill |
-| `refillThresholdPumps` | `0` | Trigger refill alert when remaining pump count is at or below this value |
+| `fullLiquidGrams` | `600 g` | Weight used as the full-liquid calibration reference for the demo |
+| `refillAlertPercent` | `10%` | Trigger refill alert when remaining percentage is at or below this value |
+| `minHandDistanceMm` | `70 mm` | Lower bound of distance-trigger detection range |
+| `maxHandDistanceMm` | `150 mm` | Upper bound of distance-trigger detection range |
 | `dispenseLockoutMs` | `2000 ms` | Prevent repeated dispensing from one hand gesture |
-| `stabiliseDelayMs` | `1200 ms` | Wait after servo movement before reading weight |
+| `stabiliseDelayMs` | `1200 ms` | Wait after servo movement before calculating post-dispense weight |
 | `statusIntervalMs` | `5000 ms` | Regular idle dashboard update interval |
 
 ## Alert Logic
 
-The basic refill condition is:
-
-```text
-refillAlert = remainingPumps <= refillThresholdPumps
-```
-
 The remaining percentage is:
 
 ```text
-remainingPercent = clamp((remainingPumps / maxPumps) * 100, 0, 100)
+remainingPercent = clamp((liquidWeightGrams / fullLiquidGrams) * 100, 0, 100)
+```
+
+The refill condition is:
+
+```text
+refillAlert = remainingPercent <= refillAlertPercent
+```
+
+The latest dispense amount is:
+
+```text
+lastDispenseGrams = max(previousLiquidWeightGrams - currentLiquidWeightGrams, 0)
 ```
 
 ## Control Inputs
@@ -69,6 +79,7 @@ Before hardware arrives, firmware functions may return simulated values. After h
 
 - `readHandDetected()`
 - `performDispense()`
-- `readRemainingPumps()` (or future `readStableWeight()` when HX711 is reintroduced)
+- `readWeightMeasurement()`
+- `sampleMeasurements()`
 
 The state machine, Blynk virtual pin mapping, and dashboard fields should remain unchanged.

--- a/docs/integration_test_plan.md
+++ b/docs/integration_test_plan.md
@@ -7,16 +7,16 @@ Use this checklist when the ordered hardware and 3D printed part are available. 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
 | Wi-Fi connection | Upload the firmware with real Wi-Fi and Blynk credentials | Device appears online in Blynk | Screenshot of online widget |
-| Virtual pin update | Run mock mode and send `d` in Serial Monitor | `usageCount`, `remainingPumps`, and `deviceState` update | Screenshot of Blynk dashboard |
+| Virtual pin update | Run mock mode and send `d` in Serial Monitor | `usageCount`, `liquidWeightGrams`, `remainingPercent`, and `deviceState` update | Screenshot of Blynk dashboard |
 | Control inputs | Press manual dispense, reset alert, and system enable switch | ESP32 state changes correctly | Short video or screenshots |
 
-## Phase 2: IR Sensor
+## Phase 2: Distance Sensor
 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
-| Basic detection | Print raw/digital IR reading in Serial Monitor | Hand presence is clearly detectable | Serial output screenshot |
+| Basic detection | Print corrected VL53L1X distance reading in Serial Monitor | Hand presence is clearly detectable between 70 mm and 150 mm | Serial output screenshot |
 | False trigger check | Leave the sensor idle for 2 minutes | No unexpected dispense event | Serial output or observation |
-| Lockout check | Hold hand near sensor | Only one dispense event occurs per lockout period | Serial output or video |
+| Lockout check | Hold hand near sensor | Only one dispense event occurs until the hand leaves and re-enters the detection range | Serial output or video |
 
 ## Phase 3: Servo Mechanism
 
@@ -26,39 +26,40 @@ Use this checklist when the ordered hardware and 3D printed part are available. 
 | Bottle press | Mount bottle and trigger one press | One usable sanitizer output is produced | Short video |
 | Power stability | Trigger repeated presses | ESP32 does not reset or disconnect | Observation notes |
 
-## Phase 4: Pump Count and Refill Logic
+## Phase 4: Weight and Refill Logic
 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
-| Counter update | Trigger repeated dispense cycles in mock mode | `remainingPumps` decreases by one per accepted cycle | Serial output |
+| Weight update | Trigger repeated dispense cycles in real hardware mode | `liquidWeightGrams` decreases after accepted cycles | Serial CSV output |
 | Lockout safety | Hold trigger input active | Counter increases once per lockout window | Serial output or video |
-| Refill threshold | Continue until `remainingPumps = 0` | `refillAlert` becomes true and state enters `REFILL_REQUIRED` | Dashboard screenshot |
-| Alert reset | Trigger `resetAlert` from Blynk | Counter resets and alert clears | Dashboard screenshot |
+| Refill threshold | Reduce measured liquid until `remainingPercent <= 10` | `refillAlert` becomes true and state enters `REFILL_REQUIRED` | Dashboard screenshot |
+| Alert reset | Refill bottle and trigger `resetAlert` from Blynk | Weight is reread and alert clears when above threshold | Dashboard screenshot |
 
 ## Phase 5: Full System
 
 | Test | Method | Expected Result | Evidence |
 | --- | --- | --- | --- |
-| End-to-end dispense | Hand triggers IR sensor | Servo presses, usage count increments, remaining count updates, dashboard refreshes | Video of complete flow |
-| Low sanitizer flow | Simulate depleted count (`remainingPumps = 0`) | Dashboard shows refill warning | Screenshot |
+| End-to-end dispense | Hand enters distance trigger range | Servo presses, usage count increments, liquid weight updates, dashboard refreshes | Video of complete flow |
+| Low sanitizer flow | Reduce measured liquid until `remainingPercent <= 10` | Dashboard shows refill warning | Screenshot |
 | Reset after refill | Refill and press reset alert | Status returns to normal | Screenshot |
-| 3D printed enclosure test | Install all components in printed structure | IR alignment, servo motion, and counting/sync remain reliable | Video and notes |
+| 3D printed enclosure test | Install all components in printed structure | Distance sensor alignment, servo motion, weight readings, and sync remain reliable | Video and notes |
 
 ## Recommended Integration Order
 
 1. Keep the firmware in mock mode until Blynk widgets and virtual pins are confirmed.
-2. Replace `readHandDetected()` with real IR logic and test without servo movement.
-3. Replace `performDispense()` with real servo control and verify one cycle per trigger.
-4. Validate count and alert logic with repeated trigger tests and reset operations.
-5. Assemble the 3D printed structure only after the electronics work on the bench.
-6. Recalibrate servo angles and load cell readings after final assembly.
+2. Switch to real hardware mode and verify VL53L1X distance readings without triggering the servo repeatedly.
+3. Verify HX711 weight readings with empty bottle, known 600 ml reference, and repeated stable samples.
+4. Verify `performDispense()` with real servo control and confirm one cycle per trigger.
+5. Validate usage count, liquid weight, remaining percentage, and alert logic with repeated trigger tests and reset operations.
+6. Assemble the 3D printed structure only after the electronics work on the bench.
+7. Recalibrate servo angles and load cell readings after final assembly.
 
 ## Demo Acceptance Criteria
 
 The final demo is acceptable when one hand-triggered event can reliably produce this complete chain:
 
 ```text
-IR detection -> servo press -> usage count +1 -> remaining count update -> refill decision -> Blynk/dashboard update
+distance detection -> servo press -> usage count +1 -> weight update -> refill decision -> Blynk/dashboard update
 ```
 
 Collect at least one screenshot or short video for each major subsystem. These become useful evidence for the final report and presentation.

--- a/docs/software_functionalities.md
+++ b/docs/software_functionalities.md
@@ -6,16 +6,16 @@ This document summarises the software functionalities for the current SmartSan d
 
 The current SmartSan prototype is based on:
 - ESP32 as the main controller
-- IR sensor for hand detection
+- VL53L1X distance sensor for hand detection
 - Servo motor for bottle pressing
-- pump-count estimation for sanitizer level monitoring (HX711 can be added later)
+- HX711 load cell for sanitizer liquid-weight monitoring
 - Blynk dashboard as the primary mobile interface
 - Local browser interface as a mock/demo fallback
 
 The current direction is to:
-- use pump-count as the current level-monitoring method
-- keep weight sensor integration as a future enhancement
-- keep ToF only as a backup option
+- use liquid weight as the current level-monitoring method
+- keep pump-count estimation only as a mock-mode fallback
+- use the distance sensor as the primary automatic trigger
 - focus first on a reliable monitoring workflow instead of advanced analytics
 - use simulated sensor values before hardware arrives so the software flow can be tested early
 
@@ -24,14 +24,14 @@ The current direction is to:
 ## Main Software Functions
 
 ### 1. Hand Detection
-The system continuously reads the IR sensor and decides whether a valid hand-detection event has occurred.
+The system continuously reads the VL53L1X distance sensor and decides whether a valid hand-detection event has occurred.
 
 **Purpose**
 - detect a user hand in the valid sensing range
 - avoid false triggers from small fluctuations
 
 **Input**
-- IR sensor reading
+- corrected distance reading in millimetres
 
 **Output**
 - `handDetected = true/false`
@@ -70,18 +70,19 @@ Each successful dispense is recorded as one valid usage event.
 
 ---
 
-### 4. Remaining Pump Tracking
-The system tracks how many dispense actions are likely left in the current refill cycle.
+### 4. Liquid Weight Tracking
+The system tracks the estimated grams of liquid left in the current refill cycle.
 
 **Purpose**
-- provide a practical remaining-level estimate before full weight-sensor integration
+- provide a practical remaining-level estimate from the calibrated load cell
 
 **Input**
-- successful dispense count
-- configured `MAX_PUMPS` per refill
+- HX711 raw reading
+- empty-bottle zero point
+- calibration factor
 
 **Output**
-- `remainingPumps`
+- `liquidWeightGrams`
 - `remainingPercent`
 
 ---
@@ -103,15 +104,16 @@ The system applies lockout and delay logic to avoid repeated dispensing from one
 ---
 
 ### 6. Sanitizer Level Monitoring
-The remaining pump count is compared with a refill threshold to determine whether the sanitizer level is normal or low.
+The remaining percentage is compared with a refill threshold to determine whether the sanitizer level is normal or low.
 
 **Purpose**
 - monitor remaining sanitizer level
 - support condition-based refill alerts
 
 **Input**
-- `remainingPumps`
-- `refillThresholdPumps`
+- `liquidWeightGrams`
+- `remainingPercent`
+- `refillAlertPercent`
 
 **Output**
 - `sanitizerLow = true/false`
@@ -170,7 +172,7 @@ The browser page shows key monitoring information plus sync health for testing w
 
 **Current Display Fields**
 - usage count
-- remaining pumps
+- liquid weight
 - remaining percentage
 - sanitizer status
 - device state
@@ -184,7 +186,7 @@ The browser page shows key monitoring information plus sync health for testing w
 
 The current minimum viable software flow is:
 
-`IR detects hand -> servo presses bottle -> usage count updates -> remaining count is updated -> refill status is checked -> status is sent by Wi-Fi -> browser page displays result`
+`distance sensor detects hand -> servo presses bottle -> usage count updates -> liquid weight is updated -> refill status is checked -> status is sent by Wi-Fi -> browser page displays result`
 
 ---
 
@@ -194,7 +196,7 @@ The current software priority is:
 1. hand detection
 2. dispensing control
 3. usage event recording
-4. remaining pump tracking
+4. liquid weight tracking
 5. lockout and stabilisation window
 6. sanitizer level monitoring
 7. refill alert logic
@@ -214,7 +216,7 @@ At this stage, the software should not focus too much on:
 - advanced analytics
 - prediction models
 - too many admin-side functions
-- full ToF integration
+- advanced prediction beyond the current distance/weight workflow
 
 These can be considered later after the basic monitoring workflow is stable.
 
@@ -226,7 +228,7 @@ The software for the current SmartSan design is intended to support:
 - automatic hand detection
 - controlled dispensing
 - usage recording
-- pump-count based level monitoring
+- weight-based level monitoring
 - refill warning
 - browser-based monitoring
 

--- a/docs/software_test_checklist.md
+++ b/docs/software_test_checklist.md
@@ -9,8 +9,8 @@ This checklist focuses on software functionality that can be validated before fu
 | SW-01 | Sensor-triggered dispense | Click `Simulate Sensor Dispense` | State transitions through `HAND_DETECTED` -> `DISPENSING` -> `WAIT_STABILISE` -> `IDLE/REFILL_REQUIRED` |
 | SW-02 | Manual dispense command | Click `Manual Dispense` | One dispense cycle is executed and `usageCount` increments by 1 |
 | SW-03 | Single-cycle safety | Click dispense repeatedly during one running cycle | Only one active cycle runs, buttons remain disabled until cycle ends |
-| SW-04 | Refill alert trigger | Trigger cycles until `remainingPumps` reaches threshold | `Sanitizer Status` changes to `LOW` and state moves to `REFILL_REQUIRED` |
-| SW-05 | Alert reset path | Click `Reset Alert` | `remainingPumps` resets to max and warning returns to `NORMAL` |
+| SW-04 | Refill alert trigger | Reduce mock/real liquid level until `remainingPercent` reaches threshold | `Sanitizer Status` changes to `LOW` and state moves to `REFILL_REQUIRED` |
+| SW-05 | Alert reset path | Click `Reset Alert` after refill or mock reset | Liquid weight/percentage returns to a normal range and warning returns to `NORMAL` |
 
 ## Sync and Failure Handling
 
@@ -33,7 +33,7 @@ This checklist focuses on software functionality that can be validated before fu
 | Test ID | Scenario | Steps | Expected Result |
 | --- | --- | --- | --- |
 | SW-12 | Session summary update | Run 3-5 dispense cycles | `Session Dispenses` increments and `Usage Intensity` updates from LOW to MEDIUM |
-| SW-13 | Rule-based refill risk | Reduce remaining pumps to low values | `Refill Risk` changes from LOW/MEDIUM/HIGH/CRITICAL according to remaining percentage |
+| SW-13 | Rule-based refill risk | Reduce remaining percentage to low values | `Refill Risk` changes from LOW/MEDIUM/HIGH/CRITICAL according to remaining percentage |
 | SW-14 | Operator hint behavior | Toggle sync failure, disable system, and trigger refill required | `Operator Hint` updates to actionable guidance for each state |
 
 ## Evidence to Capture

--- a/docs/team_testing_guide.md
+++ b/docs/team_testing_guide.md
@@ -110,6 +110,21 @@ Only move to this phase after the mock and Blynk control tests pass.
 | VL53L1X SDA | `D4` | `PIN_DISTANCE_SDA` |
 | VL53L1X SCL | `D5` | `PIN_DISTANCE_SCL` |
 
+Optional status LEDs are supported but disabled by default. Only enable them after wiring LEDs with resistors to unused pins:
+
+| LED | Board Pin | Firmware Constant |
+| --- | --- | --- |
+| Green / normal | `D6` | `PIN_LED_GREEN` |
+| Orange / low or disabled | `D7` | `PIN_LED_ORANGE` |
+| Red / refill or error | `D8` | `PIN_LED_RED` |
+
+To enable LEDs in real hardware mode, set:
+
+```cpp
+#define USE_MOCK_HARDWARE 0
+#define ENABLE_STATUS_LEDS 1
+```
+
 5. Upload the firmware.
 6. Place a hand between `70 mm` and `150 mm` from the distance sensor.
 7. Expected result:
@@ -117,6 +132,29 @@ Only move to this phase after the mock and Blynk control tests pass.
    - Servo performs one press-and-return cycle.
    - Serial Monitor prints CSV samples with `time_ms,distance_mm,load_raw,liquid_g,remaining_percent,last_dispense_g,state,event`.
    - Blynk metrics update after the accepted cycle.
+
+## Notes on `SmartSan_prototype_simple.ino`
+
+The teammate-provided simplified sketch is useful as a logic reference, but do not upload it as a drop-in replacement for the current repository firmware without changes.
+
+Main mismatches found:
+
+| Area | Simplified sketch | Current project contract |
+| --- | --- | --- |
+| Hand detection | IR sensor on GPIO `2` | VL53L1X distance sensor on `D4`/`D5` |
+| Servo | GPIO `5`, angle `0 -> 60` | `D1`, angle `90 -> 15` |
+| HX711 | GPIO `21`/`22`, uncalibrated relative units | `D2`/`D3`, calibrated empty-bottle zero and grams conversion |
+| Blynk `V2` | Current weight | `remainingPercent` |
+| Blynk `V4` | Bottle status | `deviceState` |
+| Blynk `V5` | Device state | `lastDispenseAt` |
+| Blynk `V7` | Remaining pumps | `liquidWeightGrams` |
+| Credentials | Hardcoded placeholders in the sketch | Local ignored `secrets.h` file |
+
+The current source of truth remains:
+
+```text
+firmware/SmartSanESP32/SmartSanESP32.ino
+```
 
 ## Evidence To Capture
 

--- a/docs/team_testing_guide.md
+++ b/docs/team_testing_guide.md
@@ -18,7 +18,7 @@ The current firmware starts in mock hardware mode:
 #define USE_MOCK_HARDWARE 1
 ```
 
-In this mode, the real IR sensor and servo are not used. A Serial Monitor command simulates a hand-detection event.
+In this mode, the real VL53L1X distance sensor, HX711 load cell, and servo are not used. A Serial Monitor command simulates a hand-detection event.
 
 ## One-Time Local Setup
 
@@ -39,7 +39,9 @@ In this mode, the real IR sensor and servo are not used. A Serial Monitor comman
 | `V4` | `deviceState` | ESP32 to Blynk | State string such as `IDLE` or `DISPENSING` |
 | `V5` | `lastDispenseAt` | ESP32 to Blynk | Runtime label for last dispense |
 | `V6` | `deviceOnline` | ESP32 to Blynk | `1` when Blynk is connected |
-| `V7` | `remainingPumps` | ESP32 to Blynk | Remaining mock pump count |
+| `V7` | `liquidWeightGrams` | ESP32 to Blynk | Estimated liquid weight in grams |
+| `V8` | `distanceMm` | ESP32 to Blynk | Corrected distance sensor reading |
+| `V9` | `lastDispenseGrams` | ESP32 to Blynk | Estimated grams used by the latest dispense |
 | `V10` | `manualDispense` | Blynk to ESP32 | Button input, send `1` to trigger one cycle |
 | `V11` | `resetAlert` | Blynk to ESP32 | Button input, send `1` to reset refill count |
 | `V12` | `systemEnabled` | Blynk to ESP32 | Switch input, `1` enabled and `0` disabled |
@@ -55,12 +57,12 @@ In this mode, the real IR sensor and servo are not used. A Serial Monitor comman
 [MOCK] Trigger dispense
 [MOCK] Dispense start
 [MOCK] Dispense end
-[COUNT] Total: 1 | Session: 1 | Remaining: 24
+[COUNT] Total: 1 | Session: 1 | Remaining %: 96 | Liquid g: 576.0
 ```
 
 5. Expected Blynk changes:
    - `usageCount` increases by 1.
-   - `remainingPumps` decreases by 1.
+   - `liquidWeightGrams` decreases.
    - `remainingPercent` updates.
    - `deviceState` moves through `HAND_DETECTED`, `DISPENSING`, `WAIT_STABILISE`, then back to `IDLE`.
 
@@ -73,7 +75,7 @@ Run these tests after the mock firmware test works.
 | Manual dispense | Press the `manualDispense` widget mapped to `V10` | One dispense cycle runs |
 | Disable system | Set `systemEnabled` on `V12` to `0` | Device state becomes `DISABLED`; dispense is blocked |
 | Re-enable system | Set `systemEnabled` on `V12` to `1` | Device returns to `IDLE` or `REFILL_REQUIRED` |
-| Reset refill alert | Press `resetAlert` on `V11` | `remainingPumps` resets to `25`; alert clears |
+| Reset refill alert | Press `resetAlert` on `V11` | Mock mode resets liquid weight to `600 g`; real mode rereads the load cell and clears only if weight is above the refill threshold |
 
 ## If `d` or `D` Has No Response
 
@@ -82,7 +84,7 @@ Check these items in order:
 1. Confirm the uploaded sketch is `firmware/SmartSanESP32/SmartSanESP32.ino`.
 2. Confirm Serial Monitor is set to `115200`.
 3. Confirm `USE_MOCK_HARDWARE` is `1`.
-4. Confirm the ESP32 is connected to Wi-Fi and Blynk. `Blynk.begin(...)` can block the sketch if credentials or token are incorrect.
+4. Confirm the ESP32 has uploaded successfully. The current firmware uses non-blocking Blynk connection logic, so Serial Monitor samples should still print even if Wi-Fi/Blynk is not connected yet.
 5. Confirm `systemEnabled` is `1` in Blynk.
 6. Wait at least 2 seconds between repeated sends because the firmware has a dispense lockout.
 
@@ -90,25 +92,30 @@ Check these items in order:
 
 Only move to this phase after the mock and Blynk control tests pass.
 
-1. Install the `ESP32Servo` library in Arduino IDE.
+1. Install the `VL53L1X`, `HX711`, and `ESP32Servo` libraries in Arduino IDE.
 2. Change the firmware to:
 
 ```cpp
 #define USE_MOCK_HARDWARE 0
 ```
 
-3. Wire the hardware according to the current firmware constants:
+3. Select the board package that supports the connected XIAO ESP32 `D1`-style pin labels.
+4. Wire the hardware according to the current firmware constants:
 
-| Hardware | ESP32 GPIO | Firmware Constant |
+| Hardware | Board Pin | Firmware Constant |
 | --- | --- | --- |
-| IR sensor digital output | GPIO 2 | `PIN_IR_SENSOR` |
-| Servo signal | GPIO 5 | `PIN_SERVO` |
+| Servo signal | `D1` | `PIN_SERVO` |
+| HX711 DT / DOUT | `D2` | `PIN_LOADCELL_DOUT` |
+| HX711 SCK / CLK | `D3` | `PIN_LOADCELL_SCK` |
+| VL53L1X SDA | `D4` | `PIN_DISTANCE_SDA` |
+| VL53L1X SCL | `D5` | `PIN_DISTANCE_SCL` |
 
-4. Upload the firmware.
-5. Place a hand near the IR sensor.
-6. Expected result:
-   - Serial Monitor prints `[IR] Hand detected`.
+5. Upload the firmware.
+6. Place a hand between `70 mm` and `150 mm` from the distance sensor.
+7. Expected result:
+   - Serial Monitor prints `[DISTANCE] Hand detected at ... mm`.
    - Servo performs one press-and-return cycle.
+   - Serial Monitor prints CSV samples with `time_ms,distance_mm,load_raw,liquid_g,remaining_percent,last_dispense_g,state,event`.
    - Blynk metrics update after the accepted cycle.
 
 ## Evidence To Capture
@@ -118,6 +125,7 @@ Each tester should capture:
 - One screenshot of Blynk after a successful mock `d` test.
 - One screenshot or short video of the `manualDispense` Blynk control working.
 - One screenshot showing `systemEnabled = 0` blocks dispensing.
-- If hardware is connected, one short video of IR detection triggering the servo and Blynk updates.
+- If hardware is connected, one short video of distance detection triggering the servo and Blynk updates.
+- A copied CSV sample from Serial Monitor covering at least 10 dispense attempts.
 
 Record any failure with the exact step number, Serial Monitor output, Blynk widget values, and whether mock mode or real hardware mode was used.

--- a/firmware/SmartSanESP32/SmartSanESP32.ino
+++ b/firmware/SmartSanESP32/SmartSanESP32.ino
@@ -2,7 +2,8 @@
   SmartSan ESP32 firmware.
 
   Mock mode keeps the original Serial Monitor test path. Real hardware mode uses
-  the hardware group's VL53L1X distance sensor, HX711 load cell, and servo logic.
+  the hardware group's VL53L1X distance sensor, HX711 load cell, servo logic,
+  and optional status LEDs.
 */
 
 // Blynk configuration
@@ -23,6 +24,9 @@ const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";
 // Set to 0 after the hardware wiring and Arduino libraries are ready.
 #define USE_MOCK_HARDWARE 1
 
+// Optional: set to 1 only after wiring LEDs to the status LED pins below.
+#define ENABLE_STATUS_LEDS 0
+
 #include <WiFi.h>
 #include <BlynkSimpleEsp32.h>
 
@@ -41,6 +45,13 @@ const int PIN_LOADCELL_DOUT = D2;
 const int PIN_LOADCELL_SCK = D3;
 const int PIN_DISTANCE_SDA = D4;
 const int PIN_DISTANCE_SCL = D5;
+#endif
+
+#if !USE_MOCK_HARDWARE && ENABLE_STATUS_LEDS
+// Optional status LEDs. Keep D1-D5 reserved for servo, HX711, and VL53L1X.
+const int PIN_LED_GREEN = D6;
+const int PIN_LED_ORANGE = D7;
+const int PIN_LED_RED = D8;
 #endif
 
 // Distance trigger settings
@@ -183,6 +194,44 @@ void updateRemainingMetrics() {
 
 void updateRefillAlert() {
   refillAlert = remainingPercent <= REFILL_ALERT_PERCENT;
+}
+
+void setupStatusLeds() {
+#if !USE_MOCK_HARDWARE && ENABLE_STATUS_LEDS
+  pinMode(PIN_LED_GREEN, OUTPUT);
+  pinMode(PIN_LED_ORANGE, OUTPUT);
+  pinMode(PIN_LED_RED, OUTPUT);
+
+  digitalWrite(PIN_LED_GREEN, LOW);
+  digitalWrite(PIN_LED_ORANGE, LOW);
+  digitalWrite(PIN_LED_RED, LOW);
+#endif
+}
+
+void setStatusLeds(bool greenOn, bool orangeOn, bool redOn) {
+#if !USE_MOCK_HARDWARE && ENABLE_STATUS_LEDS
+  digitalWrite(PIN_LED_GREEN, greenOn ? HIGH : LOW);
+  digitalWrite(PIN_LED_ORANGE, orangeOn ? HIGH : LOW);
+  digitalWrite(PIN_LED_RED, redOn ? HIGH : LOW);
+#else
+  (void)greenOn;
+  (void)orangeOn;
+  (void)redOn;
+#endif
+}
+
+void updateStatusLeds() {
+  if (deviceState == STATE_ERROR) {
+    setStatusLeds(false, false, true);
+  } else if (!systemEnabled || deviceState == STATE_DISABLED) {
+    setStatusLeds(false, true, false);
+  } else if (refillAlert) {
+    setStatusLeds(false, false, true);
+  } else if (remainingPercent <= 40) {
+    setStatusLeds(false, true, false);
+  } else {
+    setStatusLeds(true, false, false);
+  }
 }
 
 void printCsvHeaderOnce() {
@@ -330,6 +379,7 @@ void sampleMeasurements(const char* eventName) {
 
   updateRemainingMetrics();
   updateRefillAlert();
+  updateStatusLeds();
   printCsvSample(eventName);
 }
 
@@ -365,6 +415,7 @@ void setState(DeviceState nextState) {
   deviceState = nextState;
   stateStartedMs = millis();
   sendStatus();
+  updateStatusLeds();
 }
 
 bool hasLiquidAvailable() {
@@ -566,6 +617,8 @@ BLYNK_WRITE(V12) {
 void setup() {
   Serial.begin(115200);
   delay(100);
+
+  setupStatusLeds();
 
 #if !USE_MOCK_HARDWARE
   setupHardware();

--- a/firmware/SmartSanESP32/SmartSanESP32.ino
+++ b/firmware/SmartSanESP32/SmartSanESP32.ino
@@ -1,11 +1,8 @@
 /*
-  SmartSan ESP32 firmware skeleton.
+  SmartSan ESP32 firmware.
 
-  This sketch uses simulated IR and servo behaviour so the Blynk dashboard and state
-  machine can be tested early. Weight sensing (HX711) is planned but currently
-  replaced with pump-count logic for the prototype.
-  Set USE_MOCK_HARDWARE to 0 when the real sensors
-  are ready and replace the hardware adapter functions near the bottom.
+  Mock mode keeps the original Serial Monitor test path. Real hardware mode uses
+  the hardware group's VL53L1X distance sensor, HX711 load cell, and servo logic.
 */
 
 // Blynk configuration
@@ -23,37 +20,48 @@ const char WIFI_SSID[] = "REPLACE_WITH_WIFI_NAME";
 const char WIFI_PASS[] = "REPLACE_WITH_WIFI_PASSWORD";
 #endif
 
-// IR sensor configuration - adjust as needed for the actual sensor and placement
-#define PIN_IR_SENSOR     2
-#define IR_ACTIVE_LOW     true
-#define IR_DEBOUNCE_MS    80
-
-// Servo configuration - adjust pin and angles as needed for the actual mechanism
-#define PIN_SERVO         5
-
-#define USE_MOCK_HARDWARE 1 // Set to 0 to use real hardware when ready
-
-// Hardware libraries (servo only used when not in mock mode)
-#if !USE_MOCK_HARDWARE // Only include servo library if not using mock hardware, to avoid unnecessary dependencies during early testing
-#include <ESP32Servo.h>
-#endif
+// Set to 0 after the hardware wiring and Arduino libraries are ready.
+#define USE_MOCK_HARDWARE 1
 
 #include <WiFi.h>
 #include <BlynkSimpleEsp32.h>
 
-//ir sensor variables for debounce logic and stable state detection
-static bool _irLastState = false;
-static bool _irStableState = false;
-static unsigned long _irLastChangeMs = 0;
-static bool _dispensingActive = false;  // prevents overlapping dispense cycles
-static bool _irEventConsumed = true;
+#if !USE_MOCK_HARDWARE
+#include <Wire.h>
+#include <VL53L1X.h>
+#include <ESP32Servo.h>
+#include "HX711.h"
+#endif
 
-// Servo timing and angles - adjust as needed for the actual mechanism
-const int SERVO_HOME_DEG  = 0;
-const int SERVO_PRESS_DEG = 60;
-const int SERVO_PRESS_MS  = 400;
-const int SERVO_RETURN_MS = 300;
-const int SERVO_SETTLE_MS = 100;
+// Hardware pin map from project_iot_adjustment.ino.
+// D pin labels are used by the selected XIAO ESP32 board package in Arduino IDE.
+#if !USE_MOCK_HARDWARE
+const int PIN_SERVO = D1;
+const int PIN_LOADCELL_DOUT = D2;
+const int PIN_LOADCELL_SCK = D3;
+const int PIN_DISTANCE_SDA = D4;
+const int PIN_DISTANCE_SCL = D5;
+#endif
+
+// Distance trigger settings
+const int MIN_HAND_DISTANCE_MM = 70;
+const int MAX_HAND_DISTANCE_MM = 150;
+const int DISTANCE_OFFSET_MM = 5;
+
+// Servo settings from the hardware integration sketch
+const int SERVO_HOME_DEG = 90;
+const int SERVO_PRESS_DEG = 15;
+const int SERVO_STEP_DELAY_MS = 35;
+const int SERVO_HOLD_MS = 700;
+const int SERVO_RETURN_SETTLE_MS = 1000;
+
+// HX711 load cell calibration from the hardware group.
+// Empty bottle is treated as 0 g liquid weight.
+const long LOADCELL_ZERO_RAW = 1045992;
+const float LOADCELL_CALIBRATION_FACTOR = 2153.3;
+const float FULL_LIQUID_GRAMS = 600.0;
+const float EMPTY_NOISE_GRAMS = 5.0;
+const int REFILL_ALERT_PERCENT = 10;
 
 // Blynk virtual pin definitions
 const int PIN_USAGE_COUNT = V0;
@@ -62,22 +70,23 @@ const int PIN_REFILL_ALERT = V3;
 const int PIN_DEVICE_STATE = V4;
 const int PIN_LAST_DISPENSE_AT = V5;
 const int PIN_DEVICE_ONLINE = V6;
-const int PIN_REMAINING_PUMPS = V7; // NEW: raw remaining pumps for debugging, replaced current weight reading pin
+const int PIN_LIQUID_WEIGHT_GRAMS = V7;
+const int PIN_DISTANCE_MM = V8;
+const int PIN_LAST_DISPENSE_GRAMS = V9;
 const int PIN_MANUAL_DISPENSE = V10;
 const int PIN_RESET_ALERT = V11;
 const int PIN_SYSTEM_ENABLED = V12;
 
 // Device and state machine variables
-const int MAX_PUMPS = 25; // TODO: calibrate by counting full bottle dispenses
+const int MAX_PUMPS = 25;
 const unsigned long DISPENSE_LOCKOUT_MS = 2000;
 const unsigned long STABILISE_DELAY_MS = 1200;
 const unsigned long STATUS_INTERVAL_MS = 5000;
-const unsigned long STABILISE_TIMEOUT_MS = 5000; // watchdog timeout for dispense cycle
-const unsigned long ERROR_RECOVERY_MS = 8000; // Time to wait in error state before allowing reset, can be adjusted based on expected recovery time or user intervention needs
+const unsigned long MEASUREMENT_INTERVAL_MS = 500;
+const unsigned long BLYNK_RECONNECT_INTERVAL_MS = 10000;
+const unsigned long STABILISE_TIMEOUT_MS = 5000;
+const unsigned long ERROR_RECOVERY_MS = 8000;
 
-unsigned long lastErrorLogMs = 0; // For rate-limiting error logs to avoid spamming during error conditions
-
-// State machine states
 enum DeviceState {
   STATE_IDLE,
   STATE_HAND_DETECTED,
@@ -90,22 +99,42 @@ enum DeviceState {
   STATE_ERROR
 };
 
-// Global variables
 DeviceState deviceState = STATE_IDLE;
 
 #if !USE_MOCK_HARDWARE
-Servo dispenserServo; // Servo object for controlling the dispenser mechanism
+VL53L1X distanceSensor;
+Servo dispenserServo;
+HX711 scale;
 #endif
+
 int usageCount = 0;
 int sessionCount = 0;
-int remainingPumps = MAX_PUMPS;
+int remainingPumpsEstimate = MAX_PUMPS;
+int remainingPercent = 100;
 bool refillAlert = false;
 bool systemEnabled = true;
 bool manualDispenseRequested = false;
 bool resetAlertRequested = false;
+bool dispensingActive = false;
+bool handPresent = false;
+bool distanceSensorReady = false;
+bool scaleReady = false;
+
+long loadCellRaw = 0;
+float liquidWeightGrams = FULL_LIQUID_GRAMS;
+float previousLiquidWeightGrams = FULL_LIQUID_GRAMS;
+float lastDispenseGrams = 0.0;
+int distanceRawMm = 0;
+int distanceMm = 0;
+
 unsigned long lastDispenseMs = 0;
 unsigned long stateStartedMs = 0;
 unsigned long lastStatusMs = 0;
+unsigned long lastMeasurementMs = 0;
+unsigned long lastErrorLogMs = 0;
+unsigned long lastBlynkReconnectMs = 0;
+
+bool csvHeaderPrinted = false;
 
 String stateToString(DeviceState state) {
   switch (state) {
@@ -128,9 +157,208 @@ String stateToString(DeviceState state) {
     case STATE_ERROR:
       return "ERROR";
     default:
-      Serial.println("[WARN] Unknown DeviceState encountered");
       return "UNKNOWN_STATE";
   }
+}
+
+float clampFloat(float value, float lower, float upper) {
+  if (value < lower) {
+    return lower;
+  }
+
+  if (value > upper) {
+    return upper;
+  }
+
+  return value;
+}
+
+void updateRemainingMetrics() {
+  float percent = (liquidWeightGrams / FULL_LIQUID_GRAMS) * 100.0;
+  remainingPercent = (int)(clampFloat(percent, 0.0, 100.0) + 0.5);
+
+  float pumpEstimate = (remainingPercent / 100.0) * MAX_PUMPS;
+  remainingPumpsEstimate = (int)(clampFloat(pumpEstimate, 0.0, MAX_PUMPS) + 0.5);
+}
+
+void updateRefillAlert() {
+  refillAlert = remainingPercent <= REFILL_ALERT_PERCENT;
+}
+
+void printCsvHeaderOnce() {
+  if (csvHeaderPrinted) {
+    return;
+  }
+
+  Serial.println("time_ms,distance_mm,load_raw,liquid_g,remaining_percent,last_dispense_g,state,event");
+  csvHeaderPrinted = true;
+}
+
+void printCsvSample(const char* eventName) {
+  printCsvHeaderOnce();
+  Serial.print(millis());
+  Serial.print(",");
+  Serial.print(distanceMm);
+  Serial.print(",");
+  Serial.print(loadCellRaw);
+  Serial.print(",");
+  Serial.print(liquidWeightGrams, 1);
+  Serial.print(",");
+  Serial.print(remainingPercent);
+  Serial.print(",");
+  Serial.print(lastDispenseGrams, 1);
+  Serial.print(",");
+  Serial.print(stateToString(deviceState));
+  Serial.print(",");
+  Serial.println(eventName);
+}
+
+void connectBlynk() {
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  Blynk.config(BLYNK_AUTH_TOKEN);
+
+  Serial.print("[WIFI] Connecting to ");
+  Serial.println(WIFI_SSID);
+
+  if (Blynk.connect(5000)) {
+    Serial.println("[BLYNK] Connected");
+  } else {
+    Serial.println("[BLYNK] Not connected yet; local Serial testing will continue");
+  }
+}
+
+void runBlynkConnection() {
+  if (WiFi.status() != WL_CONNECTED) {
+    return;
+  }
+
+  if (!Blynk.connected() && millis() - lastBlynkReconnectMs >= BLYNK_RECONNECT_INTERVAL_MS) {
+    lastBlynkReconnectMs = millis();
+    Blynk.connect(1000);
+  }
+
+  if (Blynk.connected()) {
+    Blynk.run();
+  }
+}
+
+#if !USE_MOCK_HARDWARE
+void setupHardware() {
+  Wire.begin(PIN_DISTANCE_SDA, PIN_DISTANCE_SCL);
+
+  distanceSensor.setTimeout(500);
+  if (!distanceSensor.init()) {
+    Serial.println("[ERROR] Distance sensor failed");
+    deviceState = STATE_ERROR;
+  } else {
+    distanceSensor.startContinuous(50);
+    distanceSensorReady = true;
+    Serial.println("[HW] Distance sensor started");
+  }
+
+  dispenserServo.attach(PIN_SERVO);
+  dispenserServo.write(SERVO_HOME_DEG);
+  delay(500);
+  Serial.println("[HW] Servo ready");
+
+  scale.begin(PIN_LOADCELL_DOUT, PIN_LOADCELL_SCK);
+  if (!scale.is_ready()) {
+    Serial.println("[ERROR] HX711 not found. Check DT/SCK wiring.");
+    deviceState = STATE_ERROR;
+  } else {
+    scaleReady = true;
+    Serial.println("[HW] HX711 ready");
+  }
+}
+
+bool readDistanceMeasurement() {
+  if (!distanceSensorReady) {
+    return false;
+  }
+
+  distanceRawMm = distanceSensor.read();
+
+  if (distanceSensor.timeoutOccurred()) {
+    Serial.println("[WARN] Distance sensor timeout");
+    return false;
+  }
+
+  distanceMm = distanceRawMm - DISTANCE_OFFSET_MM;
+  if (distanceMm < 0) {
+    distanceMm = 0;
+  }
+
+  return true;
+}
+
+bool readWeightMeasurement() {
+  if (!scaleReady) {
+    return false;
+  }
+
+  if (!scale.is_ready()) {
+    Serial.println("[WARN] HX711 not ready");
+    scaleReady = false;
+    return false;
+  }
+
+  loadCellRaw = scale.read_average(10);
+  liquidWeightGrams = (loadCellRaw - LOADCELL_ZERO_RAW) / LOADCELL_CALIBRATION_FACTOR;
+
+  if (liquidWeightGrams > -EMPTY_NOISE_GRAMS && liquidWeightGrams < EMPTY_NOISE_GRAMS) {
+    liquidWeightGrams = 0.0;
+  }
+
+  if (liquidWeightGrams < 0.0) {
+    liquidWeightGrams = 0.0;
+  }
+
+  return true;
+}
+#endif
+
+void sampleMeasurements(const char* eventName) {
+#if USE_MOCK_HARDWARE
+  liquidWeightGrams = (remainingPumpsEstimate * FULL_LIQUID_GRAMS) / MAX_PUMPS;
+  loadCellRaw = 0;
+  distanceRawMm = 0;
+  distanceMm = 0;
+#else
+  readDistanceMeasurement();
+  readWeightMeasurement();
+#endif
+
+  updateRemainingMetrics();
+  updateRefillAlert();
+  printCsvSample(eventName);
+}
+
+void sampleMeasurementsIfDue() {
+  if (millis() - lastMeasurementMs < MEASUREMENT_INTERVAL_MS) {
+    return;
+  }
+
+  lastMeasurementMs = millis();
+  sampleMeasurements("sample");
+}
+
+void sendStatus() {
+  updateRemainingMetrics();
+  updateRefillAlert();
+
+  if (!Blynk.connected()) {
+    return;
+  }
+
+  Blynk.virtualWrite(PIN_USAGE_COUNT, usageCount);
+  Blynk.virtualWrite(PIN_REMAINING_PERCENT, remainingPercent);
+  Blynk.virtualWrite(PIN_REFILL_ALERT, refillAlert ? 1 : 0);
+  Blynk.virtualWrite(PIN_DEVICE_STATE, stateToString(deviceState));
+  Blynk.virtualWrite(PIN_LAST_DISPENSE_AT, lastDispenseMs == 0 ? "--" : String(lastDispenseMs / 1000) + "s");
+  Blynk.virtualWrite(PIN_DEVICE_ONLINE, 1);
+  Blynk.virtualWrite(PIN_LIQUID_WEIGHT_GRAMS, liquidWeightGrams);
+  Blynk.virtualWrite(PIN_DISTANCE_MM, distanceMm);
+  Blynk.virtualWrite(PIN_LAST_DISPENSE_GRAMS, lastDispenseGrams);
 }
 
 void setState(DeviceState nextState) {
@@ -139,24 +367,20 @@ void setState(DeviceState nextState) {
   sendStatus();
 }
 
-void sendStatus() { //updating logic with pump count instead of weight
-  int remainingPercent = (remainingPumps * 100) / MAX_PUMPS;
-  remainingPercent = constrain(remainingPercent, 0, 100);
-
-  Blynk.virtualWrite(PIN_USAGE_COUNT, usageCount);
-  Blynk.virtualWrite(PIN_REMAINING_PERCENT, remainingPercent);
-  Blynk.virtualWrite(PIN_REFILL_ALERT, refillAlert ? 1 : 0);
-  Blynk.virtualWrite(PIN_DEVICE_STATE, stateToString(deviceState));
-  Blynk.virtualWrite(PIN_LAST_DISPENSE_AT, lastDispenseMs == 0 ? "--" : String(lastDispenseMs / 1000) + "s");
-  Blynk.virtualWrite(PIN_DEVICE_ONLINE, Blynk.connected() ? 1 : 0);
-
-  // NEW: raw remaining pumps
-  Blynk.virtualWrite(PIN_REMAINING_PUMPS, remainingPumps); //cleaner version
+bool hasLiquidAvailable() {
+  return remainingPercent > REFILL_ALERT_PERCENT;
 }
 
-bool canStartDispense() { 
-  // hard single-dispense lock
-  if (_dispensingActive) {
+bool hardwareReadyForDispense() {
+#if USE_MOCK_HARDWARE
+  return true;
+#else
+  return distanceSensorReady && scaleReady;
+#endif
+}
+
+bool canStartDispense() {
+  if (dispensingActive) {
     Serial.println("[GUARD] Dispense already active");
     return false;
   }
@@ -169,32 +393,36 @@ bool canStartDispense() {
     return false;
   }
 
-  if (remainingPumps <= 0) {
+  if (!hardwareReadyForDispense()) {
+    Serial.println("[BLOCK] Hardware not ready");
+    return false;
+  }
+
+  if (!hasLiquidAvailable()) {
     return false;
   }
 
   return deviceState == STATE_IDLE || deviceState == STATE_REFILL_REQUIRED;
 }
 
-void startDispenseCycle() { // updated to check if dispense can start, and set active flag to prevent multiple triggers during dispensing
-
+void startDispenseCycle() {
   if (!systemEnabled) {
     setState(STATE_DISABLED);
     return;
   }
 
   if (!canStartDispense()) {
-
-    if (remainingPumps <= 0) {
-      Serial.println("[BLOCK] Bottle empty");
+    if (!hardwareReadyForDispense()) {
+      setState(STATE_ERROR);
+    } else if (!hasLiquidAvailable()) {
+      Serial.println("[BLOCK] Refill required");
       setState(STATE_REFILL_REQUIRED);
     }
 
     return;
   }
 
-  _dispensingActive = true;
-
+  dispensingActive = true;
   setState(STATE_HAND_DETECTED);
 }
 
@@ -205,8 +433,7 @@ void updateStateMachine() {
       if (manualDispenseRequested) {
         manualDispenseRequested = false;
         startDispenseCycle();
-      }
-      else if (readHandDetected()) {
+      } else if (readHandDetected()) {
         startDispenseCycle();
       }
       break;
@@ -216,46 +443,57 @@ void updateStateMachine() {
       setState(STATE_DISPENSING);
       break;
 
-    case STATE_DISPENSING: // update usage and remaining pump count
-      if (sessionCount < MAX_PUMPS) {
-        usageCount += 1;
-        sessionCount += 1;
+    case STATE_DISPENSING:
+      usageCount += 1;
+      sessionCount += 1;
+
+#if USE_MOCK_HARDWARE
+      if (remainingPumpsEstimate > 0) {
+        remainingPumpsEstimate -= 1;
       }
+      liquidWeightGrams = (remainingPumpsEstimate * FULL_LIQUID_GRAMS) / MAX_PUMPS;
+      lastDispenseGrams = FULL_LIQUID_GRAMS / MAX_PUMPS;
+#endif
 
-      remainingPumps = MAX_PUMPS - sessionCount;
-
+      updateRemainingMetrics();
       lastDispenseMs = millis();
-
-      // release dispense lock
-      _dispensingActive = false;
+      dispensingActive = false;
 
       Serial.print("[COUNT] Total: ");
       Serial.print(usageCount);
       Serial.print(" | Session: ");
       Serial.print(sessionCount);
-      Serial.print(" | Remaining: ");
-      Serial.println(remainingPumps);
+      Serial.print(" | Remaining %: ");
+      Serial.print(remainingPercent);
+      Serial.print(" | Liquid g: ");
+      Serial.println(liquidWeightGrams, 1);
 
       setState(STATE_WAIT_STABILISE);
       break;
 
-    case STATE_WAIT_STABILISE: // allow dispense cycle to fully complete before next state
-
+    case STATE_WAIT_STABILISE:
       if (millis() - stateStartedMs >= STABILISE_DELAY_MS) {
         setState(STATE_CHECK_REFILL);
         break;
       }
 
-      // watchdog protection
       if (millis() - stateStartedMs >= STABILISE_TIMEOUT_MS) {
         Serial.println("[ERROR] WAIT_STABILISE timeout");
         setState(STATE_ERROR);
       }
-
       break;
 
-    case STATE_CHECK_REFILL: 
-      refillAlert = (remainingPumps <= 0);
+    case STATE_CHECK_REFILL:
+#if !USE_MOCK_HARDWARE
+      sampleMeasurements("post_weight");
+      lastDispenseGrams = previousLiquidWeightGrams - liquidWeightGrams;
+      if (lastDispenseGrams < 0.0) {
+        lastDispenseGrams = 0.0;
+      }
+      printCsvSample("post_dispense");
+#endif
+      updateRemainingMetrics();
+      updateRefillAlert();
       setState(STATE_UPDATE_STATUS);
       break;
 
@@ -263,46 +501,52 @@ void updateStateMachine() {
       setState(refillAlert ? STATE_REFILL_REQUIRED : STATE_IDLE);
       break;
 
-    case STATE_DISABLED: // Ensure system is fully inactive and reset session count, but keep total usage for stats
-      _dispensingActive = false;
+    case STATE_DISABLED:
+      dispensingActive = false;
 
       if (systemEnabled) {
         setState(refillAlert ? STATE_REFILL_REQUIRED : STATE_IDLE);
       }
-
       break;
 
-    case STATE_ERROR: // In error state, block all actions and require manual reset, but allow status updates to show error condition
-
+    case STATE_ERROR:
       if (millis() - lastErrorLogMs >= 2000) {
         lastErrorLogMs = millis();
         Serial.println("[ERROR] System in STATE_ERROR");
       }
 
       if (millis() - stateStartedMs >= ERROR_RECOVERY_MS) {
+        Serial.println("[RECOVERY] Attempting system recovery");
+        dispensingActive = false;
+        sampleMeasurements("recovery");
 
-        Serial.println("[RECOVERY] Recovering system");
-
-        _dispensingActive = false;
-
-        setState(systemEnabled ? STATE_IDLE : STATE_DISABLED);
+        if (hardwareReadyForDispense()) {
+          setState(systemEnabled ? STATE_IDLE : STATE_DISABLED);
+        } else {
+          Serial.println("[RECOVERY] Hardware still not ready");
+          stateStartedMs = millis();
+        }
       }
-
       break;
   }
 
-  if (resetAlertRequested) { // Reset session count and refill alert, but keep total usage count.
+  if (resetAlertRequested) {
     resetAlertRequested = false;
 
-    sessionCount = 0;
-    remainingPumps = MAX_PUMPS;
-    refillAlert = false;
+#if USE_MOCK_HARDWARE
+    remainingPumpsEstimate = MAX_PUMPS;
+    liquidWeightGrams = FULL_LIQUID_GRAMS;
+#else
+    sampleMeasurements("reset");
+#endif
 
-    _dispensingActive = false;  // FIX: unlock dispensing state
+    lastDispenseGrams = 0.0;
+    updateRemainingMetrics();
+    updateRefillAlert();
+    dispensingActive = false;
 
-    Serial.println("[RESET] Refill confirmed");
-
-    setState(systemEnabled ? STATE_IDLE : STATE_DISABLED);
+    Serial.println("[RESET] Refill reset requested");
+    setState(systemEnabled ? (refillAlert ? STATE_REFILL_REQUIRED : STATE_IDLE) : STATE_DISABLED);
   }
 }
 
@@ -316,29 +560,29 @@ BLYNK_WRITE(V11) {
 
 BLYNK_WRITE(V12) {
   systemEnabled = param.asInt() == 1;
-  setState(systemEnabled ? STATE_IDLE : STATE_DISABLED);
+  setState(systemEnabled ? (refillAlert ? STATE_REFILL_REQUIRED : STATE_IDLE) : STATE_DISABLED);
 }
 
-void setup() { 
+void setup() {
   Serial.begin(115200);
   delay(100);
 
-  pinMode(PIN_IR_SENSOR, INPUT); // Set IR sensor pin as input
+#if !USE_MOCK_HARDWARE
+  setupHardware();
+#else
+  Serial.println("[MOCK] Hardware simulation enabled");
+#endif
 
-  Blynk.begin(BLYNK_AUTH_TOKEN, WIFI_SSID, WIFI_PASS); // Connect to WiFi and Blynk
+  sampleMeasurements("boot");
+  connectBlynk();
 
-  #if !USE_MOCK_HARDWARE
-    dispenserServo.attach(PIN_SERVO); // Attach servo to pin  
-    dispenserServo.write(SERVO_HOME_DEG); // Move servo to home position
-    delay(500);
-  #endif
-
-  _dispensingActive = false;
-  setState(STATE_IDLE);
+  dispensingActive = false;
+  setState(deviceState == STATE_ERROR ? STATE_ERROR : STATE_IDLE);
 }
 
 void loop() {
-  Blynk.run();
+  runBlynkConnection();
+  sampleMeasurementsIfDue();
   updateStateMachine();
 
   if (millis() - lastStatusMs >= STATUS_INTERVAL_MS) {
@@ -347,73 +591,67 @@ void loop() {
   }
 }
 
-bool readHandDetected() { //updated logic to use IR sensor with debounce and stable state detection, replacing the old mock logic of reading from serial input
-  #if USE_MOCK_HARDWARE
-    if (Serial.available() == 0) {
-      return false;
-    }
-
-    char command = Serial.read();
-
-    if (command == 'd' || command == 'D') {
-      Serial.println("[MOCK] Trigger dispense");
-      return true;
-    }
-
+bool readHandDetected() {
+#if USE_MOCK_HARDWARE
+  if (Serial.available() == 0) {
     return false;
-  #else
-    bool rawDetected = IR_ACTIVE_LOW
-      ? (digitalRead(PIN_IR_SENSOR) == LOW)
-      : (digitalRead(PIN_IR_SENSOR) == HIGH);
+  }
 
-    unsigned long now = millis();
+  char command = Serial.read();
 
-    if (rawDetected != _irLastState) {
-      _irLastChangeMs = now;
-      _irLastState = rawDetected;
-    }
+  if (command == 'd' || command == 'D') {
+    Serial.println("[MOCK] Trigger dispense");
+    return true;
+  }
 
-    if ((now - _irLastChangeMs) >= IR_DEBOUNCE_MS) {
-      _irStableState = _irLastState;
-    }
-
-    if (_irStableState && _irEventConsumed) {
-      _irEventConsumed = false;
-      return false;
-    }
-
-    if (_irStableState && !_irEventConsumed) {
-      _irEventConsumed = true;
-      Serial.println("[IR] Hand detected");
-      return true;
-    }
-
-    if (!_irStableState) {
-      _irEventConsumed = true;
-    }
-
+  return false;
+#else
+  if (!readDistanceMeasurement()) {
     return false;
-  #endif
+  }
+
+  bool inRange = distanceMm >= MIN_HAND_DISTANCE_MM && distanceMm <= MAX_HAND_DISTANCE_MM;
+
+  if (inRange && !handPresent) {
+    handPresent = true;
+    Serial.print("[DISTANCE] Hand detected at ");
+    Serial.print(distanceMm);
+    Serial.println(" mm");
+    return true;
+  }
+
+  if (!inRange) {
+    handPresent = false;
+  }
+
+  return false;
+#endif
 }
 
-//updated to use servo for dispensing, replacing old mock logic of reading from serial input
 void performDispense() {
 #if USE_MOCK_HARDWARE
   Serial.println("[MOCK] Dispense start");
   delay(200);
   Serial.println("[MOCK] Dispense end");
-
 #else
+  readWeightMeasurement();
+  previousLiquidWeightGrams = liquidWeightGrams;
+
   Serial.println("[SERVO] Press started");
 
-  delay(SERVO_SETTLE_MS);
+  for (int angle = SERVO_HOME_DEG; angle >= SERVO_PRESS_DEG; angle--) {
+    dispenserServo.write(angle);
+    delay(SERVO_STEP_DELAY_MS);
+  }
 
-  dispenserServo.write(SERVO_PRESS_DEG);
-  delay(SERVO_PRESS_MS);
+  delay(SERVO_HOLD_MS);
 
-  dispenserServo.write(SERVO_HOME_DEG);
-  delay(SERVO_RETURN_MS);
+  for (int angle = SERVO_PRESS_DEG; angle <= SERVO_HOME_DEG; angle++) {
+    dispenserServo.write(angle);
+    delay(SERVO_STEP_DELAY_MS);
+  }
 
+  delay(SERVO_RETURN_SETTLE_MS);
   Serial.println("[SERVO] Cycle complete");
 #endif
 }

--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@
 
     .content { padding: 24px 28px; overflow-y: auto; flex: 1; display: flex; flex-direction: column; gap: 20px; }
 
-    .stat-row { display: grid; grid-template-columns: repeat(5,1fr); gap: 14px; }
+    .stat-row { display: grid; grid-template-columns: repeat(6,1fr); gap: 14px; }
     .stat-card { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 18px; }
     .stat-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .8px; margin-bottom: 10px; font-family: 'DM Mono', monospace; }
     .stat-value { font-size: 32px; font-weight: 600; line-height: 1; font-family: 'DM Mono', monospace; }
@@ -87,7 +87,7 @@
     .feed-tag.info {
       background: rgba(56,189,248,.15);
       color: var(--blue);
-    }    
+    }
     .feed-tag.warn  { background: rgba(251,191,36,.15);  color: var(--yellow); }
     .feed-tag.error { background: rgba(248,113,113,.15); color: var(--red); }
     .feed-tag.ok    { background: rgba(74,222,128,.15);  color: var(--green); }
@@ -134,7 +134,7 @@
       <div class="logo-dot">💧</div>
       <div>
         <div class="logo-text">SmartSan</div>
-        <div class="logo-sub">v0.6 · mock mode</div>
+        <div class="logo-sub">v0.7 · hardware map</div>
       </div>
     </div>
     <div class="nav-section">
@@ -146,7 +146,7 @@
     <div style="flex:1"></div>
     <div style="padding:8px; background:var(--surface2); border-radius:10px; border:1px solid var(--border);">
       <div style="font-size:11px; color:var(--muted); font-family:'DM Mono',monospace; margin-bottom:4px;">ESP32 data contract</div>
-      <div style="font-size:11px; color:var(--muted);">V0 usageCount · V2 remaining%<br>V3 refillAlert · V4 state<br>V7 remainingPumps · V10–V12 ctrl</div>
+      <div style="font-size:11px; color:var(--muted);">V0 usage · V2 remaining% · V3 alert<br>V4 state · V5 lastAt · V6 online<br>V7 weight · V8 distance · V9 dispense</div>
     </div>
   </aside>
 
@@ -170,47 +170,54 @@
           <div class="stat-sub">lifetime dispenses</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Remaining</div>
-          <div class="stat-value good" id="statRemaining">25</div>
-          <div class="stat-sub" id="statRemainingPct">100% full</div>
+          <div class="stat-label">Liquid Weight</div>
+          <div class="stat-value good" id="statWeight">0</div>
+          <div class="stat-sub" id="statWeightSub">g measured by HX711</div>
         </div>
         <div class="stat-card">
-          <div class="stat-label">Status</div>
+          <div class="stat-label">Bottle Status</div>
+          <div class="stat-value good" id="statBottle">UNKNOWN</div>
+          <div class="stat-sub" id="statBottleSub">FULL / LOW / EMPTY</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Estimated Remaining</div>
+          <div class="stat-value good" id="statRemaining">25</div>
+          <div class="stat-sub" id="statRemainingPct">from V2 remainingPercent</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Refill Alert</div>
           <div class="stat-value good" id="statStatus">NORMAL</div>
           <div class="stat-sub" id="statStatusSub">threshold OK</div>
         </div>
         <div class="stat-card">
           <div class="stat-label">Device State</div>
           <div class="stat-value" id="statState" style="font-size:20px">IDLE</div>
-          <div class="stat-sub" id="statStateSub">ready</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-label">Connectivity</div>
-          <div class="stat-value good" id="statOnline">ONLINE</div>
-          <div class="stat-sub" id="statOnlineSub">Blynk connected</div>
+          <div class="stat-sub" id="statStateSub">firmware state</div>
         </div>
       </div>
 
       <div class="main-grid">
         <div class="panel">
-          <div class="panel-title">Refill Prediction</div>
+          <div class="panel-title">Bottle Overview</div>
           <div class="prediction-main">
             <div class="prediction-time" id="predTime">--</div>
-            <div class="prediction-unit" id="predUnit">hrs remaining</div>
+            <div class="prediction-unit" id="predUnit">g measured</div>
           </div>
           <div class="level-bar-wrap">
             <div class="level-bar-track">
-              <div id="levelBarFill" class="level-bar-fill" style="width:40%; background:var(--green)"></div>
+              <div id="levelBarFill" class="level-bar-fill" style="width:100%; background:var(--green)"></div>
             </div>
             <div class="level-label">
-              <span id="levelBarLabel">40% · 10 pumps</span>
-              <span id="levelBarHint" style="color:var(--muted)">est. time-to-empty</span>
+              <span id="levelBarLabel">estimated 100% remaining</span>
+              <span id="levelBarHint" style="color:var(--muted)">prototype estimate</span>
             </div>
           </div>
           <div class="prediction-rows">
-            <div class="pred-row"><span class="pred-label">Avg rate</span><span class="pred-val" id="predRate">-- disp/hr</span></div>
-            <div class="pred-row"><span class="pred-label">Session dispenses</span><span class="pred-val" id="predSession">0</span></div>
-            <div class="pred-row"><span class="pred-label">Refill risk</span><span class="pred-val" id="predRisk">LOW</span></div>
+            <div class="pred-row"><span class="pred-label">Bottle status</span><span class="pred-val" id="predBottle">UNKNOWN</span></div>
+            <div class="pred-row"><span class="pred-label">Estimated remaining</span><span class="pred-val" id="predRemaining">25 pumps</span></div>
+            <div class="pred-row"><span class="pred-label">Distance</span><span class="pred-val" id="predDistance">-- mm</span></div>
+            <div class="pred-row"><span class="pred-label">Last dispense amount</span><span class="pred-val" id="predLastDispense">-- g</span></div>
+            <div class="pred-row"><span class="pred-label">Refill alert</span><span class="pred-val" id="predRisk">NORMAL</span></div>
             <div class="pred-row"><span class="pred-label">Operator hint</span><span class="pred-val" id="predHint">No action needed</span></div>
           </div>
         </div>
@@ -251,7 +258,7 @@
             <div class="health-row"><div class="health-label">State Machine</div><div id="hStateMachine" class="health-val good">RUNNING</div></div>
             <div class="health-row"><div class="health-label">Dispense Lock</div><div id="hDispenseLock" class="health-val good">FREE</div></div>
             <div class="health-row"><div class="health-label">Lockout</div><div id="hLockout" class="health-val">CLEAR</div></div>
-            <div class="health-row"><div class="health-label">Last Dispense</div><div id="hLastDispense" class="health-val">--</div></div>
+            <div class="health-row"><div class="health-label">Last Dispense At</div><div id="hLastDispense" class="health-val">--</div></div>
             <div class="health-row"><div class="health-label">Uptime</div><div id="hUptime" class="health-val">--</div></div>
           </div>
         </div>
@@ -279,13 +286,20 @@ const device = {
   sessionCount:       0,
   remainingPumps:     25,
   maxPumps:           25,
+  remainingPercent:   100,
   refillAlert:        false,
+  currentWeight:      600,
+  distanceMm:         0,
+  lastDispenseGrams:  0,
+  bottleStatus:       'FULL',
+  deviceState:        'IDLE',
   systemEnabled:      true,
   dispenseInProgress: false,
   lastDispenseAt:     null,
   sessionStart:       new Date().toLocaleTimeString(),
   refillCount:        0,
   errorCount:         0,
+  deviceOnline:       true,
   online:             true,
   syncFail:           false,
   // fix #3: buckets store { count, ts } — labels anchored to real timestamps
@@ -293,6 +307,27 @@ const device = {
   events:             [],
   startMs:            Date.now(),
 };
+
+const FULL_LIQUID_GRAMS = 600;
+const MAX_LIQUID_DISPLAY_GRAMS = 700;
+const REFILL_ALERT_PERCENT = 10;
+
+const BLYNK_TOKEN = ''; // Leave empty in git; fill locally only for private Blynk API polling.
+const BLYNK_API_BASE = 'https://blynk.cloud/external/api/get?token=';
+const BLYNK_LIVE_POLL_MS = 2000;
+const LIVE_BLYNK_ENABLED = Boolean(BLYNK_TOKEN);
+const BLYNK_PINS = Object.freeze({
+  usageCount: 0,
+  remainingPercent: 2,
+  refillAlert: 3,
+  deviceState: 4,
+  lastDispenseAt: 5,
+  deviceOnline: 6,
+  liquidWeightGrams: 7,
+  distanceMm: 8,
+  lastDispenseGrams: 9,
+  systemEnabled: 12,
+});
 
 // ─────────────────────────────────────────────────────────────
 // SIM — animation timeline only, no logic authority
@@ -303,10 +338,11 @@ const sim = { phase: 'idle' };
 // UI STATE — pure derivation, no mapping layer
 // ─────────────────────────────────────────────────────────────
 function uiState() {
+  if (!device.deviceOnline)       return 'OFFLINE';
   if (!device.systemEnabled)     return 'DISABLED';
+  if (device.refillAlert || device.remainingPercent <= REFILL_ALERT_PERCENT) return 'REFILL_REQUIRED';
   if (device.dispenseInProgress) return 'DISPENSING';
-  if (device.refillAlert)        return 'REFILL_REQUIRED';
-  return 'IDLE';
+  return device.deviceState || 'IDLE';
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -316,28 +352,99 @@ const CONFIG = {
   PREDICTION_BUCKETS: 3
 };
 
+function clampNumber(value, min, max) {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return min;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function bottleStatusFromPercent(percent) {
+  if (percent <= 0) return 'EMPTY';
+  if (percent <= REFILL_ALERT_PERCENT) return 'LOW';
+  if (percent >= 90) return 'FULL';
+  return 'IN_USE';
+}
+
 function getPrediction() {
-  const pct  = Math.round((device.remainingPumps / device.maxPumps) * 100);
-  const recentBuckets = device.usageHistory.slice(-CONFIG.PREDICTION_BUCKETS);
-  const recentDispenses = recentBuckets.reduce((sum, bucket) => sum + bucket.count, 0);
-  const minutesTracked = (recentBuckets.length * 30000) / 60000;
-  const ratePerHour = minutesTracked > 0 ? (recentDispenses / minutesTracked) * 60 : null;
-  let timeStr = '--', unit = 'not enough data yet';
-  if (ratePerHour && ratePerHour > 0) {
-    const minsLeft = (device.remainingPumps / ratePerHour) * 60;
-    if (minsLeft < 60) { timeStr = Math.round(minsLeft); unit = 'min remaining'; }
-    else               { timeStr = (minsLeft / 60).toFixed(1); unit = 'hrs remaining'; }
-  }
-  if (!ratePerHour || ratePerHour <= 0) {
-    unit = 'not enough recent data yet';
-  }
-  const risk = pct <= 0 ? 'CRITICAL' : pct <= 16 ? 'HIGH' : pct <= 40 ? 'MEDIUM' : 'LOW';
+  const pct = Math.round(clampNumber(device.remainingPercent, 0, 100));
+  const remaining = Math.round((pct / 100) * device.maxPumps);
+  const bottle = bottleStatusFromPercent(pct);
+  const alert = device.refillAlert || pct <= REFILL_ALERT_PERCENT;
   const hint = !device.systemEnabled ? 'Enable system to allow dispensing'
-             : !device.online        ? 'Check Wi-Fi/Blynk connectivity'
-             : risk === 'CRITICAL'   ? 'Refill required — press reset after refilling'
-             : risk === 'HIGH'       ? 'Prepare refill soon'
+             : alert    ? 'Refill required — press reset after refilling'
+             : bottle === 'EMPTY' ? 'Bottle empty by weight'
+             : bottle === 'LOW'    ? 'Bottle getting low'
              : 'No action needed';
-  return { timeStr, unit, rate: ratePerHour ? ratePerHour.toFixed(1) : '--', risk, hint, pct };
+  const risk = alert ? 'CRITICAL' : bottle === 'EMPTY' ? 'HIGH' : bottle === 'LOW' ? 'MEDIUM' : 'LOW';
+  return {
+    weight: device.currentWeight,
+    bottle,
+    remaining,
+    pct,
+    risk,
+    hint,
+  };
+}
+
+async function fetchBlynkValue(vPin) {
+  const response = await fetch(`${BLYNK_API_BASE}${BLYNK_TOKEN}&V${vPin}`);
+  if (!response.ok) {
+    throw new Error(`Blynk fetch failed for V${vPin}`);
+  }
+  return response.text();
+}
+
+async function syncFromBlynk() {
+  if (!LIVE_BLYNK_ENABLED) {
+    return;
+  }
+
+  try {
+    const [
+      usageCount,
+      remainingPercent,
+      refillAlert,
+      deviceState,
+      lastDispenseAt,
+      deviceOnline,
+      liquidWeightGrams,
+      distanceMm,
+      lastDispenseGrams,
+      systemEnabled,
+    ] = await Promise.all([
+      fetchBlynkValue(BLYNK_PINS.usageCount),
+      fetchBlynkValue(BLYNK_PINS.remainingPercent),
+      fetchBlynkValue(BLYNK_PINS.refillAlert),
+      fetchBlynkValue(BLYNK_PINS.deviceState),
+      fetchBlynkValue(BLYNK_PINS.lastDispenseAt),
+      fetchBlynkValue(BLYNK_PINS.deviceOnline),
+      fetchBlynkValue(BLYNK_PINS.liquidWeightGrams),
+      fetchBlynkValue(BLYNK_PINS.distanceMm),
+      fetchBlynkValue(BLYNK_PINS.lastDispenseGrams),
+      fetchBlynkValue(BLYNK_PINS.systemEnabled),
+    ]);
+
+    device.usageCount = Number.parseInt(usageCount, 10) || 0;
+    device.sessionCount = device.usageCount;
+    device.remainingPercent = clampNumber(remainingPercent, 0, 100);
+    device.remainingPumps = Math.round((device.remainingPercent / 100) * device.maxPumps);
+    device.currentWeight = clampNumber(liquidWeightGrams, 0, MAX_LIQUID_DISPLAY_GRAMS);
+    device.refillAlert = refillAlert.trim() === '1';
+    device.deviceState = deviceState.trim() || 'IDLE';
+    device.lastDispenseAt = lastDispenseAt.trim() || null;
+    device.deviceOnline = deviceOnline.trim() === '1';
+    device.distanceMm = Number.parseInt(distanceMm, 10) || 0;
+    device.lastDispenseGrams = Number.parseFloat(lastDispenseGrams) || 0;
+    if (systemEnabled.trim() !== '') {
+      device.systemEnabled = systemEnabled.trim() !== '0';
+    }
+    device.bottleStatus = bottleStatusFromPercent(device.remainingPercent);
+    device.online = true;
+    render();
+  } catch (error) {
+    device.online = false;
+    console.warn('Blynk sync failed, keeping local mock data:', error);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -419,43 +526,50 @@ function render() {
   const pct   = pred.pct;
 
   document.getElementById('statUsage').textContent = device.usageCount;
+  const weightEl = document.getElementById('statWeight');
+  weightEl.textContent = `${pred.weight.toFixed(0)} g`;
+  weightEl.className = 'stat-value ' + (pred.bottle === 'EMPTY' ? 'bad' : pred.bottle === 'LOW' ? 'warn' : 'good');
+  document.getElementById('statWeightSub').textContent = 'HX711 reading (prototype mode)';
+
+  const bottleEl = document.getElementById('statBottle');
+  bottleEl.textContent = pred.bottle;
+  bottleEl.className = 'stat-value ' + (pred.bottle === 'EMPTY' ? 'bad' : pred.bottle === 'LOW' ? 'warn' : 'good');
+  document.getElementById('statBottleSub').textContent = 'FULL / IN_USE / LOW / EMPTY';
+
   const remEl = document.getElementById('statRemaining');
-  remEl.textContent = device.remainingPumps;
+  remEl.textContent = pred.remaining;
   remEl.className = 'stat-value ' + (pct <= 16 ? 'bad' : pct <= 40 ? 'warn' : 'good');
-  document.getElementById('statRemainingPct').textContent = `${pct}% full`;
+  document.getElementById('statRemainingPct').textContent = `${pct}% from V2 remainingPercent`;
 
   const statusEl = document.getElementById('statStatus');
-  statusEl.textContent = device.refillAlert ? 'LOW' : 'NORMAL';
-  statusEl.className = 'stat-value ' + (device.refillAlert ? 'bad' : 'good');
-  document.getElementById('statStatusSub').textContent = device.refillAlert ? 'refill required' : 'threshold OK';
+  const alert = device.refillAlert || pct <= REFILL_ALERT_PERCENT;
+  statusEl.textContent = alert ? 'REFILL' : 'NORMAL';
+  statusEl.className = 'stat-value ' + (alert ? 'bad' : 'good');
+  document.getElementById('statStatusSub').textContent = alert ? 'refill required' : 'threshold OK';
 
   const stEl = document.getElementById('statState');
   stEl.textContent = state;
-  stEl.className = 'stat-value' + (state === 'DISPENSING' ? ' warn' : state === 'REFILL_REQUIRED' ? ' bad' : '');
-  document.getElementById('statStateSub').textContent = device.systemEnabled ? 'enabled' : 'disabled';
-
-  const onEl = document.getElementById('statOnline');
-  onEl.textContent = device.online ? 'ONLINE' : 'OFFLINE';
-  onEl.className = 'stat-value ' + (device.online ? 'good' : 'bad');
-  document.getElementById('statOnlineSub').textContent = device.online ? 'Blynk connected' : 'connection lost';
+  stEl.className = 'stat-value' + (state === 'DISPENSING' || state === 'OFFLINE' ? ' warn' : state === 'REFILL_REQUIRED' ? ' bad' : '');
+  document.getElementById('statStateSub').textContent = !device.deviceOnline ? 'offline' : device.systemEnabled ? 'enabled' : 'disabled';
 
   document.getElementById('topbarSub').textContent =
-    `state: ${state.toLowerCase()} · ${device.remainingPumps}/${device.maxPumps} pumps · ${device.online ? 'online' : 'offline'}`;
+    `state: ${state.toLowerCase()} · ${pred.weight.toFixed(0)} g · ${pct}% · ${device.deviceOnline ? 'online' : 'offline'}`;
 
-  document.getElementById('predTime').textContent    = pred.timeStr;
-  document.getElementById('predUnit').textContent    = pred.unit;
-  document.getElementById('predRate').textContent =
-    pred.rate !== '--' ? `${pred.rate} disp/hr` : '--';
-  document.getElementById('predSession').textContent = device.sessionCount;
+  document.getElementById('predTime').textContent    = `${pred.weight.toFixed(0)}`;
+  document.getElementById('predUnit').textContent    = 'g measured';
+  document.getElementById('predBottle').textContent  = pred.bottle;
+  document.getElementById('predRemaining').textContent = `${pred.remaining} pumps`;
+  document.getElementById('predDistance').textContent = `${device.distanceMm} mm`;
+  document.getElementById('predLastDispense').textContent = `${device.lastDispenseGrams.toFixed(1)} g`;
   const riskEl = document.getElementById('predRisk');
   riskEl.textContent = pred.risk;
-  riskEl.style.color = pred.risk === 'CRITICAL' ? 'var(--red)' : pred.risk === 'HIGH' ? 'var(--yellow)' : 'var(--green)';
+  riskEl.style.color = pred.risk === 'CRITICAL' ? 'var(--red)' : (pred.risk === 'HIGH' || pred.risk === 'MEDIUM') ? 'var(--yellow)' : 'var(--green)';
   document.getElementById('predHint').textContent = pred.hint;
 
   const barFill = document.getElementById('levelBarFill');
   barFill.style.width = pct + '%';
   barFill.style.background = pct <= 16 ? 'var(--red)' : pct <= 40 ? 'var(--yellow)' : 'var(--green)';
-  document.getElementById('levelBarLabel').textContent = `${pct}% · ${device.remainingPumps} pumps`;
+  document.getElementById('levelBarLabel').textContent = `${pct}% estimated remaining · ${pred.remaining} pumps`;
 
   drawChart(device.usageHistory);
   // fix #3: labels from stored bucket timestamps, not computed from now
@@ -469,8 +583,8 @@ function render() {
 
   renderFeed();
 
-  document.getElementById('hStateMachine').textContent = device.systemEnabled ? 'RUNNING' : 'HALTED';
-  document.getElementById('hStateMachine').className   = 'health-val ' + (device.systemEnabled ? 'good' : 'warn');
+  document.getElementById('hStateMachine').textContent = !device.deviceOnline ? 'OFFLINE' : device.systemEnabled ? 'RUNNING' : 'HALTED';
+  document.getElementById('hStateMachine').className   = 'health-val ' + (!device.deviceOnline || !device.systemEnabled ? 'warn' : 'good');
   document.getElementById('hDispenseLock').textContent = device.dispenseInProgress ? 'LOCKED' : 'FREE';
   document.getElementById('hDispenseLock').className   = 'health-val ' + (device.dispenseInProgress ? 'warn' : 'good');
   document.getElementById('hLockout').textContent      = device.dispenseInProgress ? 'ACTIVE' : 'CLEAR';
@@ -499,8 +613,10 @@ function render() {
 // DISPENSE — fix #4: history bucket always in sync with sessionCount
 // ─────────────────────────────────────────────────────────────
 function doDispense(source) {
-  if (!device.systemEnabled || device.dispenseInProgress || device.remainingPumps <= 0) return;
+  if (!device.systemEnabled || device.dispenseInProgress || device.remainingPercent <= 0) return;
   device.dispenseInProgress = true;
+  device.deviceState = 'DISPENSE';
+  device.deviceOnline = true;
   sim.phase = 'triggered';
   recordEvent('info', `${source === 'manual' ? 'Manual' : 'Sensor'} dispense triggered`);
   render();
@@ -509,7 +625,11 @@ function doDispense(source) {
     sim.phase = 'settling';
     device.usageCount++;
     device.sessionCount++;
-    device.remainingPumps = Math.max(0, device.remainingPumps - 1);
+    device.lastDispenseGrams = FULL_LIQUID_GRAMS / device.maxPumps;
+    device.currentWeight = Math.max(0, device.currentWeight - device.lastDispenseGrams);
+    device.remainingPercent = Math.round((device.currentWeight / FULL_LIQUID_GRAMS) * 100);
+    device.remainingPumps = Math.round((device.remainingPercent / 100) * device.maxPumps);
+    device.bottleStatus = bottleStatusFromPercent(device.remainingPercent);
     device.lastDispenseAt = new Date().toLocaleTimeString();
     device.usageHistory[device.usageHistory.length - 1].count++;
     render();
@@ -517,13 +637,15 @@ function doDispense(source) {
   setTimeout(() => {
     sim.phase = 'done';
     device.dispenseInProgress = false;
-    device.refillAlert = device.remainingPumps <= 0;
+    device.deviceState = 'COOLDOWN';
+    device.refillAlert = device.remainingPercent <= REFILL_ALERT_PERCENT;
     if (device.refillAlert) {
       recordEvent('warn', 'Refill alert — bottle empty');
       toast('Refill required — bottle empty', 'warn');
     } else {
       recordEvent('ok', 'Dispense complete');
     }
+    setTimeout(() => { device.deviceState = 'IDLE'; render(); }, 2000);
     render();
   }, 2400);
 }
@@ -537,6 +659,10 @@ document.getElementById('btnManual').addEventListener('click', () => doDispense(
 document.getElementById('btnReset').addEventListener('click', () => {
   device.remainingPumps = device.maxPumps;
   device.refillAlert = false; device.sessionCount = 0; device.refillCount++;
+  device.remainingPercent = 100;
+  device.bottleStatus = 'FULL';
+  device.currentWeight = FULL_LIQUID_GRAMS;
+  device.lastDispenseGrams = 0;
   recordEvent('ok', 'Refill confirmed — alert reset');
   toast('Alert reset — bottle refilled', 'ok');
   render();
@@ -544,8 +670,10 @@ document.getElementById('btnReset').addEventListener('click', () => {
 
 document.getElementById('btnFullReset').addEventListener('click', () => {
   Object.assign(device, {
-    usageCount: 0, sessionCount: 0, remainingPumps: device.maxPumps,
-    refillAlert: false, systemEnabled: true, online: true, syncFail: false,
+    usageCount: 0, sessionCount: 0, remainingPumps: device.maxPumps, remainingPercent: 100,
+    refillAlert: false, systemEnabled: true, deviceOnline: true, online: true, syncFail: false,
+    currentWeight: FULL_LIQUID_GRAMS, distanceMm: 0, lastDispenseGrams: 0,
+    bottleStatus: 'FULL', deviceState: 'IDLE',
     dispenseInProgress: false, lastDispenseAt: null, refillCount: 0, errorCount: 0,
     events: [], usageHistory: Array.from({ length: 12 }, () => ({ count: 0, ts: Date.now() })),
     startMs: Date.now(), sessionStart: new Date().toLocaleTimeString(),
@@ -562,7 +690,9 @@ document.getElementById('toggleEnabled').addEventListener('change', e => {
 });
 
 document.getElementById('toggleSyncFail').addEventListener('change', e => {
-  device.syncFail = e.target.checked; device.online = !device.syncFail;
+  device.syncFail = e.target.checked;
+  device.online = !device.syncFail;
+  if (!LIVE_BLYNK_ENABLED) device.deviceOnline = !device.syncFail;
   recordEvent(device.syncFail ? 'error' : 'ok', device.syncFail ? 'Sync failure simulated' : 'Sync restored');
   if (device.syncFail) toast('Sync failure simulated', 'error');
   render();
@@ -574,7 +704,12 @@ document.getElementById('toggleSyncFail').addEventListener('change', e => {
 setInterval(() => { document.getElementById('clockPill').textContent = new Date().toLocaleTimeString(); }, 1000);
 // fix #3: new bucket gets a real timestamp on creation
 setInterval(() => { device.usageHistory.shift(); device.usageHistory.push({ count: 0, ts: Date.now() }); render(); }, 30000);
-setInterval(() => { device.online = !device.syncFail; render(); }, 5000);
+setInterval(() => {
+  device.online = !device.syncFail;
+  if (!LIVE_BLYNK_ENABLED) device.deviceOnline = !device.syncFail;
+  render();
+}, 5000);
+setInterval(syncFromBlynk, BLYNK_LIVE_POLL_MS);
 
 // fix #2: defer first render until after layout paint so canvas has real width
 requestAnimationFrame(render);


### PR DESCRIPTION
## What changed
- Updates the local HTML dashboard to follow the current SmartSan Blynk datastream contract.
- Maps weight, remaining percent, device state, distance, last dispense amount, and system status to the correct virtual pins.
- Keeps `BLYNK_TOKEN` empty so credentials are not committed.
- Reviews the teammate-provided `SmartSan_prototype_simple.ino` and documents why it should not be uploaded as-is.
- Adds optional status LED support to the official firmware, disabled by default, using D6/D7/D8 only after wiring LEDs with resistors.

## Why
The teammate-provided HTML and simplified firmware used older assumptions: V2 as weight, V4 as bottle status, V5 as device state, GPIO-based IR detection, and uncalibrated HX711 reads. The current project contract uses VL53L1X distance sensing, calibrated HX711 weight in grams, and the finalized Blynk virtual pins.

## Current source of truth
- Firmware: `firmware/SmartSanESP32/SmartSanESP32.ino`
- Blynk/dashboard contract: `docs/team_testing_guide.md` and `src/index.html`

## Testing
- Verified `USE_MOCK_HARDWARE` remains `1`.
- Verified `ENABLE_STATUS_LEDS` defaults to `0`.
- Ran `git diff --check`.
- Parsed the embedded dashboard JavaScript with macOS JavaScriptCore.
- Checked the staged diffs for accidental Blynk/Wi-Fi secrets.

## Notes for testers
- Use mock mode for local Serial/dashboard logic tests until Blynk connectivity and hardware sensor detection are stable.
- Do not upload `SmartSan_prototype_simple.ino` as a drop-in replacement; it is documented as a reference only.
- The untracked local files `project_iot_adjustment.ino` and `sketch_may7a/` are still local-only and not included in this PR.